### PR TITLE
Add colorized logging

### DIFF
--- a/ColorizedConsoleLogger.cs
+++ b/ColorizedConsoleLogger.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace cschat
+{
+	public static class ColorizedConsoleLogger
+	{
+		private static readonly Dictionary<Log.Level, (ConsoleColor Color, string Label)> LevelInfo = new()
+		{
+			[Log.Level.Verbose] = (ConsoleColor.Gray, "VERB"),
+			[Log.Level.Information] = (ConsoleColor.Cyan, "INFO"),
+			[Log.Level.Warning] = (ConsoleColor.Yellow, "WARN"),
+			[Log.Level.Error] = (ConsoleColor.Red, "ERRO")
+		};
+
+		private static readonly Dictionary<Log.Data, ConsoleColor> PropertyStyles = new()
+		{
+			[Log.Data.Timestamp] = ConsoleColor.Blue,
+			[Log.Data.GitHash] = ConsoleColor.DarkGray,
+			[Log.Data.Source] = ConsoleColor.DarkYellow,
+			[Log.Data.Method] = ConsoleColor.Yellow,
+			[Log.Data.Model] = ConsoleColor.Magenta,
+			[Log.Data.Provider] = ConsoleColor.Magenta,
+			[Log.Data.Count] = ConsoleColor.Green,
+			[Log.Data.Progress] = ConsoleColor.Green,
+			[Log.Data.ErrorCode] = ConsoleColor.Red,
+			[Log.Data.Error] = ConsoleColor.Red,
+			[Log.Data.Result] = ConsoleColor.DarkYellow,
+			[Log.Data.Response] = ConsoleColor.DarkYellow
+		};
+
+		public static void WriteColorizedLog(Dictionary<Log.Data, object> data)
+		{
+			//var success = (bool)(data.GetValueOrDefault(Log.Data.Success) ?? false);
+
+			// Write core log elements
+			WriteOrderedProperties(data);
+			//WriteColored(success ? ConsoleColor.Green : ConsoleColor.Red, success ? "✓" : "✗");
+			//Console.Write(" | ");
+
+			// Write message if present
+			if (data.TryGetValue(Log.Data.Message, out var message))
+			{
+				WriteColoredMessage(message.ToString() ?? string.Empty);
+				Console.Write(" | ");
+			}
+
+			// Write remaining properties
+			WriteRemainingProperties(data);
+			Console.WriteLine();
+
+			// Write stack trace if present
+			if (data.TryGetValue(Log.Data.Threw, out var stackTrace))
+			{
+				WriteColored(ConsoleColor.Red, $"Stack Trace: {stackTrace}");
+				Console.WriteLine();
+			}
+		}
+
+		private static void WriteOrderedProperties(Dictionary<Log.Data, object> data)
+		{
+			var orderedKeys = new[] { Log.Data.Timestamp, Log.Data.Success, Log.Data.Level, Log.Data.GitHash, Log.Data.Source, Log.Data.Method };
+
+			foreach (var key in orderedKeys)
+			{
+				if (!data.TryGetValue(key, out var value)) continue;
+
+				if (key == Log.Data.Level)
+				{
+					WriteColoredLevel((Log.Level)value);
+				}
+				else if (key == Log.Data.Success)
+				{
+					var success = (bool)(data.GetValueOrDefault(Log.Data.Success) ?? false);
+					WriteColored(success ? ConsoleColor.Green : ConsoleColor.Red, success ? "✓" : "✗");
+				}
+				else if (PropertyStyles.TryGetValue(key, out var style))
+				{
+					WriteColored(style, value.ToString() ?? string.Empty);
+				}
+				Console.Write(" | ");
+			}
+		}
+
+		private static void WriteRemainingProperties(Dictionary<Log.Data, object> data)
+		{
+			var skipProperties = new HashSet<Log.Data>
+			{
+				Log.Data.Timestamp, Log.Data.Level, Log.Data.GitHash, Log.Data.Source,
+				Log.Data.Method, Log.Data.Success, Log.Data.Message, Log.Data.Threw
+			};
+
+			foreach (var kv in data.Where(x => !skipProperties.Contains(x.Key)))
+			{
+				WriteColored(ConsoleColor.Cyan, $"{kv.Key}:");
+
+				if (PropertyStyles.TryGetValue(kv.Key, out var style))
+				{
+					WriteColored(style, kv.Value?.ToString() ?? "null");
+				}
+				else
+				{
+					WriteColored(GetValueTypeColor(kv.Value?.ToString() ?? "null"), kv.Value?.ToString() ?? "null");
+				}
+				Console.Write(" | ");
+			}
+		}
+
+		private static void WriteColoredLevel(Log.Level level)
+		{
+			var (color, label) = LevelInfo[level];
+			var originalColors = (Console.ForegroundColor, Console.BackgroundColor);
+
+			Console.ForegroundColor = ConsoleColor.Black;
+			Console.BackgroundColor = color;
+			Console.Write($" {label} ");
+
+			(Console.ForegroundColor, Console.BackgroundColor) = originalColors;
+		}
+
+		private static void WriteColoredMessage(string message)
+		{
+			var color = message.ToLower() switch
+			{
+				var m when m.Contains("successfully") || m.Contains("completed") => ConsoleColor.Green,
+				var m when m.Contains("failed") || m.Contains("error") => ConsoleColor.Red,
+				var m when m.Contains("warning") || m.Contains("retry") => ConsoleColor.Yellow,
+				_ => ConsoleColor.DarkYellow
+			};
+			WriteColored(color, message);
+		}
+
+		private static ConsoleColor GetValueTypeColor(string value) => value.ToLower() switch
+		{
+			"true" => ConsoleColor.Green,
+			"false" => ConsoleColor.Red,
+			var v when v.StartsWith('"') && v.EndsWith('"') => ConsoleColor.DarkYellow,
+			var v when bool.TryParse(v, out _) => ConsoleColor.Blue,
+			var v when int.TryParse(v, out _) || double.TryParse(v, out _) => ConsoleColor.Green,
+			var v when v.StartsWith('{') || v.StartsWith('[') => ConsoleColor.DarkCyan,
+			_ => ConsoleColor.Gray
+		};
+
+		private static void WriteColored(ConsoleColor color, string text)
+		{
+			var original = Console.ForegroundColor;
+			Console.ForegroundColor = color;
+			Console.Write(text);
+			Console.ForegroundColor = original;
+		}
+	}
+}

--- a/Commands/SystemCommands.cs
+++ b/Commands/SystemCommands.cs
@@ -22,10 +22,8 @@ public partial class CommandManager
                             Name = "show", Description = "Show the contents of the log",
                             Action = () =>
                             {
-                                var entries = Log.GetOutput().ToList();
-                                Console.WriteLine($"Log Entries [{entries.Count}]:");
-                                entries.ToList().ForEach(entry => Console.WriteLine(entry));
-                                return Task.FromResult(Command.Result.Success);
+								Log.PrintColorizedOutput();
+								return Task.FromResult(Command.Result.Success);
                             }
                         },
                         new Command

--- a/Log.cs
+++ b/Log.cs
@@ -23,22 +23,22 @@
 //     });
 // ===============================================
 
+using cschat;
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Diagnostics;
-using System.Threading.Tasks;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 
 public static class Log
 {
     public enum Data : UInt32
     {
-        Method, Level, Timestamp, Message, Success, ErrorCode, IsRetry, Threw, Caught, Exception, PlugIn, Count, Source,
-        Path, IsValid, IsAuthed, Assembly, Interface, Role, Token, SecureBase, DirectFile, Response, Progress,
-        Provider, Model, Version, GitHash, ProviderSet, Result, FilePath, Query, Name, Scores, Registered, Reason,
-        ToolName, ToolInput, ParsedInput, Enabled, Error, Reference, Goal, Step, Input, TypeToParse, PlanningFailed, 
+        Method, Level, Timestamp, Message, Success, ErrorCode, IsRetry, Threw, Caught, Count, Source,
+        Path, Response, Progress, Provider, Model, GitHash, ProviderSet, Result, FilePath, Name, 
+        Scores, Registered, Reason, ToolInput, ParsedInput, Enabled, Error, Reference, Goal, Input, TypeToParse, 
         Command, ServerName, Names, Schema, ExampleText
     }
 
@@ -249,7 +249,20 @@ public static class Log
     public static IEnumerable<string> GetOutput() => _buffer.Select(item => item.ToJson());
     public static void ClearOutput() => _buffer.Clear();
 
-    public static void Initialize()
+	public static void PrintColorizedOutput()
+	{
+		Console.ForegroundColor = ConsoleColor.Blue;
+		Console.WriteLine($"Log Entries [{_buffer.Count}]:");
+		Console.ResetColor();
+
+		_buffer.OfType<Dictionary<string, object>>()
+			   .Select(dict => dict.Where(kv => Enum.TryParse<Data>(kv.Key, out _))
+								  .ToDictionary(kv => Enum.Parse<Data>(kv.Key), kv => kv.Value))
+			   .ToList()
+			   .ForEach(ColorizedConsoleLogger.WriteColorizedLog);
+	}
+
+	public static void Initialize()
     {
         var buffer = _buffer; // Use a local reference to avoid recursion
         SetOutput((obj) =>


### PR DESCRIPTION
Adding colored logging. This makes logs more structured and readable on the console.

<img width="1631" height="634" alt="image" src="https://github.com/user-attachments/assets/defea7d8-f808-4de0-9482-1d9398e02cfb" />
