### PR TITLE
Add PRs subsystem and introducing new Table abstraction

### DIFF
--- a/Log.cs
+++ b/Log.cs
@@ -43,7 +43,7 @@ public static class Log
         Provider, Model, Version, GitHash, ProviderSet, Result, FilePath, Query, Name, Scores, Registered, Reason,
         ToolName, ToolInput, ParsedInput, Enabled, Error, Reference, Goal, Step, Input, TypeToParse, PlanningFailed,
         Command, ServerName, Names, Schema, ExampleText, MenuTop, ConsoleHeight, ConsoleWidth, InputTop, Host, Output,
-        Id,
+        Id, Kql,
     }
 
     public enum Level { Verbose, Information, Warning, Error }

--- a/Subsytems/Kusto/KustoClient.cs
+++ b/Subsytems/Kusto/KustoClient.cs
@@ -48,7 +48,9 @@ public class KustoClient : ISubsystem
     private void Connect() => Log.Method(ctx =>
     {
         // Dispatch the async refresh and don't block the caller
+        ctx.OnlyEmitOnFailure();
         _ = RefreshConnectionsAsync();
+        ctx.Succeeded();
     });
 
     private static KustoConnectionStringBuilder ApplyAuthMode(KustoConnectionStringBuilder kcsb, KustoConfig cfg)
@@ -274,6 +276,7 @@ public class KustoClient : ISubsystem
         }
 
         ctx.Append(Log.Data.Count, addOrUpdated);
+        ctx.Succeeded(0 == failures.Count);
         return (failures, addOrUpdated);
 
         static bool UriEquals(string a, string b)

--- a/Subsytems/Kusto/KustoClient.cs
+++ b/Subsytems/Kusto/KustoClient.cs
@@ -347,7 +347,7 @@ public class KustoClient : ISubsystem
 
     public bool IsConnected(string configName) => _connections.ContainsKey(configName);
 
-    public async Task<(IReadOnlyList<string> Columns, List<string[]> Rows)> QueryAsync(KustoConfig cfg, string kql)
+    public async Task<Table> QueryAsync(KustoConfig cfg, string kql)
     {
         if (!_connections.TryGetValue(cfg.Name, out var conn))
         {
@@ -370,6 +370,6 @@ public class KustoClient : ISubsystem
                 vals[i] = reader.IsDBNull(i) ? "" : Convert.ToString(reader.GetValue(i)) ?? "";
             rows.Add(vals);
         }
-        return (columns, rows);
+        return new Table(columns, rows);
     }
 }

--- a/Subsytems/PRs/PRsClient.cs
+++ b/Subsytems/PRs/PRsClient.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+[IsConfigurable("PRs")]
+[DependsOn("Kusto")]
+[DependsOn("Ado")]
+public class PRsClient : ISubsystem
+{
+    public bool IsAvailable => true;
+    private bool _active;
+
+    public bool IsEnabled
+    {
+        get => _active;
+        set
+        {
+            if (value && !_active)
+            {
+                _active = true;
+                Register();
+            }
+            else if (!value && _active)
+            {
+                Unregister();
+                _active = false;
+            }
+        }
+    }
+
+    public Type ConfigType => typeof(PRsProfile);
+
+    public void Register() => Program.commandManager.SubCommands.Add(PRsCommands.Commands(this));
+    public void Unregister() => Program.commandManager.SubCommands.RemoveAll(c => c.Name.Equals("PRs", StringComparison.OrdinalIgnoreCase));
+
+    private static KustoConfig BuiltInKustoConfig(PRsProfile p) => new KustoConfig
+    {
+        Name = $"PRs ({p.ClusterUri}/{p.AdoDatabase})",
+        ClusterUri = p.ClusterUri,
+        Database = p.AdoDatabase,
+        AuthMode = KustoAuthMode.devicecode,
+        DefaultTimeoutSeconds = Math.Max(5, p.TimeoutSeconds)
+    };
+
+    public sealed class PRRow
+    {
+        public string Category = "";        // stale | new | closed
+        public string CreatedByDisplayName = "";
+        public string CreatedByUniqueName = "";
+        public string Title = "";
+        public string Description = "";
+        public string RepositoryName = "";
+        public string RepositoryProjectName = "";
+        public string OrganizationName = "";
+        public string Link = "";
+        public string CreationDate = "";
+        public string ClosedDate = "";
+        public string Status = "";
+        public string PullRequestId = "";
+        public string AgeDays = "";        // computed for convenience
+    }
+
+    // Build a single KQL that emits Category for the three slices using shared, materialized authors set
+    public static string BuildKql(PRsProfile p)
+    {
+        if (string.IsNullOrWhiteSpace(p.ManagerAlias)) throw new ArgumentException("Profile must specify at least one Manager Alias");
+        string emList = $"\"{p.ManagerAlias}\"";
+
+        // Build vendor regex like ^(v-|x-). If none provided, VendorRx = "" (disabled).
+        var vendorPrefixes = (p.VendorPrefixes ?? new List<string>())
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Select(s => Regex.Escape(s.Trim()))
+            .ToList();
+        var vendorRx = vendorPrefixes.Count == 0 ? "" : "^(" + string.Join("|", vendorPrefixes) + ")";
+
+        // Other knobs
+        string excludedRepos = string.Join(",", p.ExcludedRepos.Select(r => $"\"{r}\""));
+        int staleMin  = Math.Max(1, p.StaleMinAgeDays);
+        int staleMax  = Math.Max(staleMin + 1, p.StaleMaxAgeDays);
+        int newWin    = Math.Max(1, p.NewWindowDays);
+        int closedWin = Math.Max(1, p.ClosedWindowDays);
+        string cherry = "cherry-pick";
+
+        // Interpolated verbatim string — no raw-triple quotes, no doubled braces.
+        var kql = $@"
+let ReportsTo = (aliases: dynamic) {{
+    cluster('1es').database('{p.AadDatabase}').AADUser
+    | where ReportsToEmailName in~ (aliases)
+    | summarize make_set(MailNickname)
+}};
+let EM = dynamic([{emList}]);
+let VendorRx = '{vendorRx}';
+let ICs = ReportsTo(toscalar(EM));
+
+// Materialize authors; exclude vendors via regex if VendorRx provided.
+let authors = materialize(
+    cluster('1es').database('{p.AadDatabase}').AADUser
+    | where MailNickname in~ (ICs)
+    | extend IsVendor = iif(isempty(VendorRx), false, tostring(MailNickname) matches regex VendorRx)
+    | where IsVendor == false
+    | project AuthorUniqueName = strcat(MailNickname, '@microsoft.com')
+);
+
+// Recently closed (for left-anti join when computing 'new')
+let ClosedLast{newWin} = materialize(
+    cluster('1es').database('{p.AdoDatabase}').PullRequest
+    | where RepositoryName !in~ (dynamic([{excludedRepos}]))
+    | where ClosedDate > ago({newWin}d)
+    | where CreatedByUniqueName in~ (authors)
+    | where isempty(Description) or not(tolower(Description) has '{cherry.ToLowerInvariant()}')
+    | project PullRequestId, OrganizationName, RepositoryProjectName, RepositoryName
+);
+
+// Base slice used by all categories
+let base = cluster('1es').database('{p.AdoDatabase}').PullRequest
+    | where RepositoryName !in~ (dynamic([{excludedRepos}]))
+    | where CreatedByUniqueName in~ (authors)
+    | where isempty(Description) or not(tolower(Description) has '{cherry.ToLowerInvariant()}')
+    | extend Link = strcat('https://', OrganizationName, '.visualstudio.com/', RepositoryProjectName, '/_git/', RepositoryName, '/pullrequest/', PullRequestId)
+    | project CreatedByDisplayName, CreatedByUniqueName, CreationDate, ClosedDate, Title, Description, Status, OrganizationName, RepositoryProjectName, RepositoryName, PullRequestId, Link;
+
+let stale = base
+    | where CreationDate < ago({staleMin}d) and CreationDate > ago({staleMax}d)
+    | where isempty(ClosedDate) and Status != 'abandoned'
+    | extend Category = 'stale';
+
+let new_open = base
+    | where CreationDate > ago({newWin}d)
+    | join kind=leftanti ClosedLast{newWin} on PullRequestId
+    | extend Category = 'new';
+
+let closed = base
+    | where ClosedDate > ago({closedWin}d)
+    | where Status <> 'abandoned'
+    | extend Category = 'closed';
+
+union stale, new_open, closed
+| extend AgeDays = iif(isempty(ClosedDate),
+                       datetime_diff('day', now(), CreationDate) * -1,
+                       datetime_diff('day', ClosedDate, CreationDate))
+| project Category, CreatedByDisplayName, CreatedByUniqueName, CreationDate, ClosedDate, Title, Description, Link, Status, OrganizationName, RepositoryProjectName, RepositoryName, PullRequestId, AgeDays
+| order by CreatedByDisplayName asc, CreationDate asc, ClosedDate asc
+";
+        return kql;
+    }
+
+    public async Task<(IReadOnlyList<string> Cols, List<string[]> Rows)> FetchAsync(PRsProfile profile) => await Log.MethodAsync(async ctx =>
+    {
+        var kusto = Program.SubsystemManager.Get<KustoClient>();
+        var kql = BuildKql(profile);
+        ctx.Append(Log.Data.Kql, kql);
+
+        // Prefer a connected UMD config that matches the 1ES endpoint if present, else use ephemeral built-in
+        var umd = Program.userManagedData.GetItems<KustoConfig>()
+            .FirstOrDefault(c => c.ClusterUri.TrimEnd('/')
+                .Equals(profile.ClusterUri.TrimEnd('/'), StringComparison.OrdinalIgnoreCase)
+                && c.Database.Equals(profile.AdoDatabase, StringComparison.OrdinalIgnoreCase));
+
+        if (umd is not null && kusto.IsConnected(umd.Name))
+            return await kusto.QueryAsync(umd, kql);
+
+        var built = BuiltInKustoConfig(profile);
+        await kusto.EnsureConnectedAsync(built);
+        return await kusto.QueryAsync(built, kql);
+    });
+}

--- a/Subsytems/PRs/PRsClient.cs
+++ b/Subsytems/PRs/PRsClient.cs
@@ -147,7 +147,7 @@ union stale, new_open, closed
         return kql;
     }
 
-    public async Task<(IReadOnlyList<string> Cols, List<string[]> Rows)> FetchAsync(PRsProfile profile) => await Log.MethodAsync(async ctx =>
+    public async Task<Table> FetchAsync(PRsProfile profile) => await Log.MethodAsync(async ctx =>
     {
         var kusto = Program.SubsystemManager.Get<KustoClient>();
         var kql = BuildKql(profile);

--- a/Subsytems/PRs/PRsCommands.cs
+++ b/Subsytems/PRs/PRsCommands.cs
@@ -25,12 +25,12 @@ public static class PRsCommands
                     }
                 },
                 new Command {
-                    Name = "report", Description = () => "Manager report (counts, oldest stale, trends)",
+                    Name = "report", Description = () => "Manager report (recent window: counts + linkable bullets)",
                     Action = async () => {
                         var prof = PickProfile(); if (prof is null) return Command.Result.Failed;
-                        Console.Write("Top N stale per IC (default 3): "); var n = int.TryParse(User.ReadLineWithHistory(), out var v) ? v : 3;
+                        Console.Write("Window (days, default 14): "); var w = int.TryParse(User.ReadLineWithHistory(), out var vv) ? vv : 14;
                         var resp = await ToolRegistry.InvokeToolAsync("tool.prs.report",
-                            new ReportPRsInput { ProfileName = prof.Name, TopN = n });
+                            new ReportPRsInput { ProfileName = prof.Name, WindowDays = w });
                         Console.WriteLine(resp);
                         return Command.Result.Success;
                     }
@@ -53,7 +53,7 @@ public static class PRsCommands
                     Name = "coach", Description = () => "Analyze PR comment threads and suggest coaching points",
                     Action = async () => {
                         var prof = PickProfile(); if (prof is null) return Command.Result.Failed;
-                        Console.Write("Max PRs per IC to analyze (default 2; oldest stale first): "); var m = int.TryParse(User.ReadLineWithHistory(), out var mv) ? mv : 2;
+                        Console.Write("Max PRs per IC to analyze (default 2; newest first): "); var m = int.TryParse(User.ReadLineWithHistory(), out var mv) ? mv : 2;
                         var resp = await ToolRegistry.InvokeToolAsync("tool.prs.coach",
                             new CoachPRsInput { ProfileName = prof.Name, MaxPerIC = m });
                         Console.WriteLine(resp);

--- a/Subsytems/PRs/PRsCommands.cs
+++ b/Subsytems/PRs/PRsCommands.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+public static class PRsCommands
+{
+    public static Command Commands(PRsClient prs)
+    {
+        return new Command
+        {
+            Name = "PRs",
+            Description = () => "PR triage & coaching (Kusto-backed)",
+            SubCommands = new List<Command>
+            {
+                new Command {
+                    Name = "fetch", Description = () => "Fetch PRs for a profile (stale/new/closed)",
+                    Action = async () => {
+                        var prof = PickProfile(); if (prof is null) return Command.Result.Failed;
+                        var resp = await ToolRegistry.InvokeToolAsync("tool.prs.fetch",
+                            new FetchPRsInput { ProfileName = prof.Name });
+                        Console.WriteLine(resp);
+                        return Command.Result.Success;
+                    }
+                },
+                new Command {
+                    Name = "report", Description = () => "Manager report (counts, oldest stale, trends)",
+                    Action = async () => {
+                        var prof = PickProfile(); if (prof is null) return Command.Result.Failed;
+                        Console.Write("Top N stale per IC (default 3): "); var n = int.TryParse(User.ReadLineWithHistory(), out var v) ? v : 3;
+                        var resp = await ToolRegistry.InvokeToolAsync("tool.prs.report",
+                            new ReportPRsInput { ProfileName = prof.Name, TopN = n });
+                        Console.WriteLine(resp);
+                        return Command.Result.Success;
+                    }
+                },
+                new Command {
+                    Name = "slice", Description = () => "Slice: stale/new/closed (filter & export)",
+                    Action = async () => {
+                        var prof = PickProfile(); if (prof is null) return Command.Result.Failed;
+                        var sliceNames = new[]{"stale","new","closed"};
+                        var sel = User.RenderMenu("Pick slice:", sliceNames.ToList());
+                        var chosen = sel ?? sliceNames[0];
+                        Console.Write("Limit (default 25): "); var lim = int.TryParse(User.ReadLineWithHistory(), out var lv) ? lv : 25;
+                        var resp = await ToolRegistry.InvokeToolAsync("tool.prs.slice",
+                            new SlicePRsInput { ProfileName = prof.Name, Slice = chosen, Limit = lim });
+                        Console.WriteLine(resp);
+                        return Command.Result.Success;
+                    }
+                },
+                new Command {
+                    Name = "coach", Description = () => "Analyze PR comment threads and suggest coaching points",
+                    Action = async () => {
+                        var prof = PickProfile(); if (prof is null) return Command.Result.Failed;
+                        Console.Write("Max PRs per IC to analyze (default 2; oldest stale first): "); var m = int.TryParse(User.ReadLineWithHistory(), out var mv) ? mv : 2;
+                        var resp = await ToolRegistry.InvokeToolAsync("tool.prs.coach",
+                            new CoachPRsInput { ProfileName = prof.Name, MaxPerIC = m });
+                        Console.WriteLine(resp);
+                        return Command.Result.Success;
+                    }
+                }
+            }
+        };
+
+        static PRsProfile? PickProfile()
+        {
+            var profiles = Program.userManagedData.GetItems<PRsProfile>().OrderBy(p => p.Name).ToList();
+            if (profiles.Count == 0) { Console.WriteLine("No PRs Profile found. Add one in Data → PRs Profile."); return null; }
+            if (profiles.Count == 1) return profiles[0];
+            var choices = profiles.Select(p => p.ToString()).ToList();
+            var sel = User.RenderMenu("Select PRs profile:", choices);
+            if (sel == null) return null;
+            var idx = choices.IndexOf(sel);
+            if (idx >= 0) return profiles[idx];
+            var name = sel.Split('(')[0].Trim();
+            return profiles.FirstOrDefault(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/Subsytems/PRs/PRsProfile.cs
+++ b/Subsytems/PRs/PRsProfile.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+// =============================
+//  PRs subsystem — Draft v1
+//  Depends on: Kusto, Ado
+//  Provides: commands (PRs fetch/report/coach) and tools (tool.prs.fetch, tool.prs.report, tool.prs.slice, tool.prs.coach)
+// =============================
+
+[UserManaged("PRs Profile", "Settings for PR triage and reporting over Azure DevOps pull requests (via 1ES Kusto)")]
+public sealed class PRsProfile
+{
+    [UserKey]
+    public string Name { get; set; } = "";
+
+    // Who is the manager (or managers) whose reports we care about?
+    [UserField(required: true, display: "Manager Alias")]
+    public string ManagerAlias { get; set; } = string.Empty;
+
+    [UserField(display: "Exclude repositories (case-insensitive; names)")]
+    public List<string> ExcludedRepos { get; set; } = new();
+
+    [UserField(display: "Vendor prefixes to exclude (MailNickname startswith)")]
+    public List<string> VendorPrefixes { get; set; } = new() { "v-" };
+
+
+    // Windows
+    [UserField(display: "Stale window: min age (days) default is 14")]
+    public int StaleMinAgeDays { get; set; } = 14; // created before 14d
+
+    [UserField(display: "Stale window: max age (days) default is 60")]
+    public int StaleMaxAgeDays { get; set; } = 60; // but not older than 60d
+
+    [UserField(display: "New window (days) default is 14")]
+    public int NewWindowDays { get; set; } = 14; // created in last 14d
+
+    [UserField(display: "Closed window (days) default is 30")]
+    public int ClosedWindowDays { get; set; } = 30; // closed in last 30d
+
+    // Kusto endpoints (override if needed)
+    [UserField(display: "Cluster URI")]
+    public string ClusterUri { get; set; } = string.Empty; //"https://1es.kusto.windows.net";
+
+    [UserField(display: "AzureDevOps DB name")]
+    public string AdoDatabase { get; set; } = string.Empty; //"AzureDevOps";
+
+    [UserField(display: "AAD DB name")]
+    public string AadDatabase { get; set; } = string.Empty; //"AzureActiveDirectory";
+
+    [UserField(display: "Timeout (seconds)")]
+    public int TimeoutSeconds { get; set; } = 30;
+
+    public override string ToString() => $"{Name} (manager:{ManagerAlias}) DB: {AdoDatabase} excluded repos: {string.Join(", ", ExcludedRepos)}";
+}

--- a/Subsytems/PRs/PRsProfile.cs
+++ b/Subsytems/PRs/PRsProfile.cs
@@ -4,12 +4,6 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 
-// =============================
-//  PRs subsystem — Draft v1
-//  Depends on: Kusto, Ado
-//  Provides: commands (PRs fetch/report/coach) and tools (tool.prs.fetch, tool.prs.report, tool.prs.slice, tool.prs.coach)
-// =============================
-
 [UserManaged("PRs Profile", "Settings for PR triage and reporting over Azure DevOps pull requests (via 1ES Kusto)")]
 public sealed class PRsProfile
 {
@@ -42,13 +36,13 @@ public sealed class PRsProfile
 
     // Kusto endpoints (override if needed)
     [UserField(display: "Cluster URI")]
-    public string ClusterUri { get; set; } = string.Empty; //"https://1es.kusto.windows.net";
+    public string ClusterUri { get; set; } = string.Empty;
 
     [UserField(display: "AzureDevOps DB name")]
-    public string AdoDatabase { get; set; } = string.Empty; //"AzureDevOps";
+    public string AdoDatabase { get; set; } = string.Empty;
 
     [UserField(display: "AAD DB name")]
-    public string AadDatabase { get; set; } = string.Empty; //"AzureActiveDirectory";
+    public string AadDatabase { get; set; } = string.Empty;
 
     [UserField(display: "Timeout (seconds)")]
     public int TimeoutSeconds { get; set; } = 30;

--- a/Subsytems/PRs/PRsTools.cs
+++ b/Subsytems/PRs/PRsTools.cs
@@ -1,0 +1,365 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Microsoft.TeamFoundation.SourceControl.WebApi;
+
+public sealed class FetchPRsInput
+{
+    [UserField(required:true, display:"Profile Name")] public string ProfileName { get; set; } = "";
+    [UserField(display:"Export Path (.csv/.json)")]   public string? Export { get; set; }
+}
+
+[IsConfigurable("tool.prs.fetch")]
+public sealed class PRsFetchTool : ITool
+{
+    public string Description => "Fetch PRs (stale/new/closed) for a profile and cache results.";
+    public string Usage       => "PRsFetch({ \"ProfileName\":\"Deployment\" })";
+    public Type   InputType   => typeof(FetchPRsInput);
+    public string InputSchema => "{\"type\":\"object\",\"properties\":{\"ProfileName\":{\"type\":\"string\"},\"Export\":{\"type\":\"string\"}},\"required\":[\"ProfileName\"]}";
+
+    public async Task<ToolResult> InvokeAsync(object input, Context ctx)
+    {
+        var p = (FetchPRsInput)input;
+        var profile = Program.userManagedData.GetItems<PRsProfile>()
+            .FirstOrDefault(x => x.Name.Equals(p.ProfileName, StringComparison.OrdinalIgnoreCase));
+        if (profile is null) return ToolResult.Failure($"No PRs Profile named '{p.ProfileName}'.", ctx);
+
+        var prs = Program.SubsystemManager.Get<PRsClient>();
+        var (cols, rows) = await prs.FetchAsync(profile);
+
+        var table = Utilities.ToTable(cols, rows, Console.WindowWidth);
+        ctx.AddToolMessage(table);
+        await ContextManager.AddContent(table, $"prs/{profile.Name}/results");
+
+        if (!string.IsNullOrWhiteSpace(p.Export))
+        {
+            var ext = Path.GetExtension(p.Export).ToLowerInvariant();
+            var content = ext switch
+            {
+                ".csv"  => Utilities.ToCsv(cols, rows),
+                ".json" => Utilities.ToJson(cols, rows),
+                _       => table
+            };
+            File.WriteAllText(p.Export!, content);
+            ctx.AddToolMessage($"Saved: {p.Export}");
+        }
+        return ToolResult.Success(table, ctx);
+    }
+}
+
+public sealed class ReportPRsInput
+{
+    [UserField(required:true, display:"Profile Name")] public string ProfileName { get; set; } = "";
+    [UserField(display:"Top N stale per IC")] public int TopN { get; set; } = 3;
+}
+
+[IsConfigurable("tool.prs.report")]
+public sealed class PRsReportTool : ITool
+{
+    public string Description => "Manager report — counts per IC, oldest stale list per IC (LLM-free + optional summary).";
+    public string Usage       => "PRsReport({ \"ProfileName\":\"Deployment\", \"TopN\":3 })";
+    public Type   InputType   => typeof(ReportPRsInput);
+    public string InputSchema => "{\"type\":\"object\",\"properties\":{\"ProfileName\":{\"type\":\"string\"},\"TopN\":{\"type\":\"integer\"}},\"required\":[\"ProfileName\"]}";
+
+    public async Task<ToolResult> InvokeAsync(object input, Context ctx)
+    {
+        var p = (ReportPRsInput)input;
+        var profile = Program.userManagedData.GetItems<PRsProfile>()
+            .FirstOrDefault(x => x.Name.Equals(p.ProfileName, StringComparison.OrdinalIgnoreCase));
+        if (profile is null) return ToolResult.Failure($"No PRs Profile named '{p.ProfileName}'.", ctx);
+
+        var prs = Program.SubsystemManager.Get<PRsClient>();
+        var (cols, rows) = await prs.FetchAsync(profile);
+
+        // Column ordinals
+        int iCat = cols.Col("Category"), iName = cols.Col("CreatedByDisplayName"), iTitle = cols.Col("Title");
+        int iLink = cols.Col("Link"), iCreated = cols.Col("CreationDate"), iClosed = cols.Col("ClosedDate"), iAge = cols.Col("AgeDays");
+
+        var items = rows.Select(r => new {
+            Category = r[iCat], Name = r[iName], Title = r[iTitle], Link = r[iLink], Created = r[iCreated], Closed = r[iClosed], Age = r[iAge]
+        }).ToList();
+
+        var byIC = items.GroupBy(x => x.Name).OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase).ToList();
+
+        var sb = new StringBuilder();
+        sb.AppendLine("Manager Briefing (counts per IC):");
+        foreach (var g in byIC)
+        {
+            int stale = g.Count(x => x.Category == "stale");
+            int fresh = g.Count(x => x.Category == "new");
+            int closed = g.Count(x => x.Category == "closed");
+            sb.AppendLine($"- {g.Key}: {stale} stale, {fresh} new, {closed} closed (30d)");
+        }
+        sb.AppendLine();
+
+        // Oldest stale per IC
+        sb.AppendLine($"Oldest stale per IC (top {Math.Max(1, p.TopN)}):");
+        foreach (var g in byIC)
+        {
+            var stale = g.Where(x => x.Category == "stale")
+                         .OrderBy(x => DateTime.TryParse(x.Created, out var d) ? d : DateTime.MaxValue)
+                         .Take(Math.Max(1, p.TopN))
+                         .ToList();
+            if (stale.Count == 0) continue;
+            sb.AppendLine($"{g.Key}:");
+            foreach (var s in stale) sb.AppendLine($"  • {s.Created[..10]} — {Utilities.TruncatePlain(s.Title, 110)} → {s.Link}");
+        }
+
+        var output = sb.ToString();
+        ctx.AddToolMessage(output);
+        await ContextManager.AddContent(output, $"prs/{profile.Name}/report");
+        return ToolResult.Success(output, ctx);
+    }
+}
+
+public sealed class SlicePRsInput
+{
+    [UserField(required:true, display:"Profile Name")] public string ProfileName { get; set; } = "";
+    [UserField(required:true, display:"Slice (stale|new|closed)")] public string Slice { get; set; } = "stale";
+    public int Limit { get; set; } = 25;
+    public string? Export { get; set; }
+}
+
+[IsConfigurable("tool.prs.slice")]
+public sealed class PRsSliceTool : ITool
+{
+    public string Description => "Filter by slice and print/export a focused list (Title, Created, Link).";
+    public string Usage       => "PRsSlice({ \"ProfileName\":\"Deployment\", \"Slice\":\"stale\", \"Limit\":25 })";
+    public Type   InputType   => typeof(SlicePRsInput);
+    public string InputSchema => "{\"type\":\"object\",\"properties\":{\"ProfileName\":{\"type\":\"string\"},\"Slice\":{\"type\":\"string\"},\"Limit\":{\"type\":\"integer\"},\"Export\":{\"type\":\"string\"}},\"required\":[\"ProfileName\",\"Slice\"]}";
+
+    public async Task<ToolResult> InvokeAsync(object input, Context ctx)
+    {
+        var p = (SlicePRsInput)input;
+        var profile = Program.userManagedData.GetItems<PRsProfile>()
+            .FirstOrDefault(x => x.Name.Equals(p.ProfileName, StringComparison.OrdinalIgnoreCase));
+        if (profile is null) return ToolResult.Failure($"No PRs Profile named '{p.ProfileName}'.", ctx);
+
+        var prs = Program.SubsystemManager.Get<PRsClient>();
+        var (cols, rows) = await prs.FetchAsync(profile);
+
+        int iCat = cols.Col("Category"), iTitle = cols.Col("Title"), iLink = cols.Col("Link"), iCreated = cols.Col("CreationDate");
+        var filtered = rows.Where(r => string.Equals(r[iCat], p.Slice, StringComparison.OrdinalIgnoreCase))
+                           .OrderBy(r => DateTime.TryParse(r[iCreated], out var d) ? d : DateTime.MaxValue)
+                           .Take(Math.Max(1, p.Limit))
+                           .ToList();
+
+        var lines = new List<string>();
+        lines.Add($"Slice: {p.Slice} (limit {p.Limit})");
+        foreach (var r in filtered) lines.Add($"- {r[iCreated][..10]} — {Utilities.TruncatePlain(r[iTitle], 120)} → {r[iLink]}");
+        var output = string.Join("\n", lines);
+
+        ctx.AddToolMessage(output);
+        await ContextManager.AddContent(output, $"prs/{profile.Name}/slice/{p.Slice}");
+
+        if (!string.IsNullOrWhiteSpace(p.Export))
+        {
+            var ext = Path.GetExtension(p.Export).ToLowerInvariant();
+            var content = ext switch
+            {
+                ".csv"  => Utilities.ToCsv(cols, filtered),
+                ".json" => Utilities.ToJson(cols, filtered),
+                _       => output
+            };
+            File.WriteAllText(p.Export!, content);
+            ctx.AddToolMessage($"Saved: {p.Export}");
+        }
+        return ToolResult.Success(output, ctx);
+    }
+}
+
+// Coach: fetch comment threads via ADO SDK and summarize recurring themes
+public sealed class CoachPRsInput
+{
+    [UserField(required:true, display:"Profile Name")] public string ProfileName { get; set; } = "";
+    [UserField(display:"Max PRs per IC to analyze")] public int MaxPerIC { get; set; } = 2;
+}
+
+[IsConfigurable("tool.prs.coach")]
+public sealed class PRsCoachTool : ITool
+{
+    public string Description => "Pull ADO PR threads (oldest stale first per IC) and produce coaching suggestions.";
+    public string Usage       => "PRsCoach({ \"ProfileName\":\"Deployment\", \"MaxPerIC\":2 })";
+    public Type   InputType   => typeof(CoachPRsInput);
+    public string InputSchema => "{\"type\":\"object\",\"properties\":{\"ProfileName\":{\"type\":\"string\"},\"MaxPerIC\":{\"type\":\"integer\"}},\"required\":[\"ProfileName\"]}";
+
+    public async Task<ToolResult> InvokeAsync(object input, Context ctx)
+    {
+        var p = (CoachPRsInput)input;
+        var profile = Program.userManagedData.GetItems<PRsProfile>()
+            .FirstOrDefault(x => x.Name.Equals(p.ProfileName, StringComparison.OrdinalIgnoreCase));
+        if (profile is null) return ToolResult.Failure($"No PRs Profile named '{p.ProfileName}'.", ctx);
+
+        var prs = Program.SubsystemManager.Get<PRsClient>();
+        var (cols, rows) = await prs.FetchAsync(profile);
+
+        int iCat = cols.Col("Category"), iName = cols.Col("CreatedByDisplayName");
+        int iOrg = cols.Col("OrganizationName"), iProj = cols.Col("RepositoryProjectName"), iRepo = cols.Col("RepositoryName"), iId = cols.Col("PullRequestId"), iCreated = cols.Col("CreationDate");
+        int iLink = cols.Col("Link");
+
+        // Build per-IC picks (oldest first) – prefer stale, fall back to new
+        var perIc = rows.Where(r => r[iCat] == "stale")
+                        .GroupBy(r => r[iName])
+                        .ToDictionary(g => g.Key, g => g.OrderBy(r => DateTime.TryParse(r[iCreated], out var d) ? d : DateTime.MaxValue)
+                                                        .Take(Math.Max(1, p.MaxPerIC))
+                                                        .Select(r => (Org: r[iOrg], Proj: r[iProj], Repo: r[iRepo], Id: int.Parse(r[iId]), Link: iLink >= 0 ? r[iLink] : string.Empty))
+                                                        .ToList());
+
+        // Fallback to “new” if there are no stale PRs at all
+        if (perIc.Count == 0)
+        {
+            perIc = rows.Where(r => r[iCat] == "new")
+                        .GroupBy(r => r[iName])
+                        .ToDictionary(g => g.Key, g => g.OrderBy(r => DateTime.TryParse(r[iCreated], out var d) ? d : DateTime.MaxValue)
+                                                        .Take(Math.Max(1, p.MaxPerIC))
+                                                        .Select(r => (Org: r[iOrg], Proj: r[iProj], Repo: r[iRepo], Id: int.Parse(r[iId]), Link: iLink >= 0 ? r[iLink] : string.Empty))
+                                                        .ToList());
+        }
+
+        var ado = Program.SubsystemManager.Get<AdoClient>();
+        var sb = new StringBuilder();
+        sb.AppendLine("Coaching Hints (by IC):");
+
+        int printed = 0;
+        foreach (var kv in perIc)
+        {
+            var ic = kv.Key; var picks = kv.Value;
+            var bullets = new List<string>();
+
+            foreach (var pr in picks)
+            {
+                List<GitPullRequestCommentThread> threads;
+                try
+                {
+                    threads = await ado.GetThreadsAsync(pr.Proj, pr.Repo, pr.Id);
+                    
+                    // Build a few concrete, actionable examples with discussion URLs
+                    var examples = new List<string>();
+
+                    IEnumerable<(int ThreadId, string Snippet)> PickExamples()
+                    {
+                        // Flatten comments with their thread id
+                        var all = threads
+                            .SelectMany(t => (t.Comments ?? new List<Comment>()).Select(c => new { t.Id, c.Content }))
+                            .Where(x => !string.IsNullOrWhiteSpace(x.Content));
+
+                        // Light-weight keyword buckets to find representative, actionable examples
+                        var buckets = new (string Tag, string[] Keys)[]
+                        {
+                            ("tests", new[] {"test", "unit", "coverage", "flaky"}),
+                            ("size",  new[] {"too big", "scope", "split", "refactor"}),
+                            ("ci",    new[] {"CI", "build", "pipeline", "fail", "flake"}),
+                            ("perf",  new[] {"perf", "latency", "alloc", "hot path"}),
+                            ("docs",  new[] {"doc", "comment", "readme", "description"}),
+                            ("style", new[] {"nit", "style", "naming", "format", "convention"}),
+                            ("merge", new[] {"merge conflict", "rebase", "out of date"})
+                        };
+
+                        // score each comment by bucket
+                        var scored = all.Select(x =>
+                        {
+                            var lower = x.Content.ToLowerInvariant();
+                            var (tag, score) = buckets
+                                .Select(b => (b.Tag, Score: b.Keys.Count(k => lower.Contains(k.ToLowerInvariant()))))
+                                .OrderByDescending(t => t.Score)
+                                .FirstOrDefault();
+                            return new { x.Id, x.Content, tag, score };
+                        })
+                        .Where(s => s.score > 0);
+
+                        // take top few distinct tags to avoid redundancy
+                        var picked = scored
+                            .GroupBy(s => s.tag)
+                            .OrderByDescending(g => g.Max(s => s.score))
+                            .Take(3)
+                            .Select(g =>
+                            {
+                                var best = g.OrderByDescending(s => s.score).First();
+                                var snippet = Utilities.TruncatePlain(best.Content.Replace("\r", " ").Replace("\n", " "), 160);
+                                return (ThreadId: best.Id, Snippet: snippet);
+                            });
+
+                        return picked;
+                    }
+
+                    foreach (var ex in PickExamples())
+                    {
+                        var tUrl = AdoClient.BuildDiscussionUrl(pr.Org, pr.Proj, pr.Repo, pr.Id, ex.ThreadId);
+                        examples.Add($"- \"{ex.Snippet}\"  \n    ↳ {tUrl}");
+                    }
+
+                    if (examples.Count > 0)
+                    {
+                        bullets.Add("Examples:\n" + string.Join("\n", examples) + "\n");
+                    }
+
+                }
+                catch (Exception ex)
+                {
+                    bullets.Add($"PR {pr.Id}: (error fetching threads) {ex.Message}");
+                    continue;
+                }
+
+                var text = string.Join("\n", threads
+                    .SelectMany(t => t.Comments?.Select(c => c.Content) ?? Enumerable.Empty<string>())
+                    .Where(s => !string.IsNullOrWhiteSpace(s)));
+
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                    bullets.Add($"PR {pr.Id}: no review comments yet.");
+                    continue;
+                }
+
+                var prompt = @"""
+You are an EM reviewing PR review threads. Summarize the recurring coaching themes in 3-5 bullets. Use short, actionable language.
+Focus areas to look for: test coverage, build/CI issues, PR size/scope, unclear descriptions, style/nits churn, rebase/merge conflicts, perf concerns, ownership or responsiveness.
+Output only bullets (no preamble). """ + "\n\n" + Utilities.TruncatePlain(text, 4000);
+
+                var summary = await Engine.Provider!.PostChatAsync(new Context(prompt), 0.2f);
+
+                var prUrl = !string.IsNullOrWhiteSpace(pr.Link)
+                    ? pr.Link
+                    : AdoClient.BuildPullRequestUrl(pr.Org, pr.Proj, pr.Repo, pr.Id);
+
+                bullets.Add($"PR {pr.Id} — {prUrl}:\n{summary.Trim()}\n");
+            }
+
+            // Always print the IC header; show “no items” if needed
+            sb.AppendLine($"{ic}:");
+            if (bullets.Count == 0)
+            {
+                sb.AppendLine("  (no actionable coaching items found)");
+            }
+            else
+            {
+                foreach (var b in bullets) sb.AppendLine("  " + b.Replace("\n", "\n  "));
+                printed++;
+            }
+        }
+
+        // If nothing at all was printed, add a friendly note
+        if (printed == 0)
+        {
+            sb.AppendLine("No stale or new PRs with review discussion were found for this profile and window.");
+        }
+
+        var output = sb.ToString();
+        ctx.AddToolMessage(output);
+        await ContextManager.AddContent(output, $"prs/{profile.Name}/coach");
+        return ToolResult.Success(output, ctx);
+    }
+}
+
+
+public static class PrsExtensions
+{
+    // Thin wrapper since GitHttpClient is already initialized in AdoClient; keep the public method here to avoid exposing internals.
+    public static async Task<List<GitPullRequestCommentThread>> GetThreadsAsync(this AdoClient ado, string project, string repoName, int prId)
+        => await ado.GetPullRequestThreadsAsync(project, repoName, prId);
+
+    public static int Col(this IReadOnlyList<string> cols, string name) =>
+        cols.Select((c, i) => new { c, i }).FirstOrDefault(x => string.Equals(x.c, name, StringComparison.OrdinalIgnoreCase))?.i ?? -1;
+
+}

--- a/Subsytems/PRs/PRsTools.cs
+++ b/Subsytems/PRs/PRsTools.cs
@@ -27,41 +27,41 @@ public sealed class PRsFetchTool : ITool
         if (profile is null) return ToolResult.Failure($"No PRs Profile named '{p.ProfileName}'.", ctx);
 
         var prs = Program.SubsystemManager.Get<PRsClient>();
-        var (cols, rows) = await prs.FetchAsync(profile);
+        var table = await prs.FetchAsync(profile);
 
-        var table = Utilities.ToTable(cols, rows, Console.WindowWidth);
-        ctx.AddToolMessage(table);
-        await ContextManager.AddContent(table, $"prs/{profile.Name}/results");
+    var rendered = table.ToText(Console.WindowWidth);
+        ctx.AddToolMessage(rendered);
+        await ContextManager.AddContent(rendered, $"prs/{profile.Name}/results");
 
         if (!string.IsNullOrWhiteSpace(p.Export))
         {
             var ext = Path.GetExtension(p.Export).ToLowerInvariant();
             var content = ext switch
             {
-                ".csv"  => Utilities.ToCsv(cols, rows),
-                ".json" => Utilities.ToJson(cols, rows),
-                _       => table
+                ".csv"  => table.ToCsv(),
+                ".json" => table.ToJson(),
+                _       => rendered
             };
             File.WriteAllText(p.Export!, content);
             ctx.AddToolMessage($"Saved: {p.Export}");
         }
-        return ToolResult.Success(table, ctx);
+        return ToolResult.Success(rendered, ctx);
     }
 }
 
 public sealed class ReportPRsInput
 {
     [UserField(required:true, display:"Profile Name")] public string ProfileName { get; set; } = "";
-    [UserField(display:"Top N stale per IC")] public int TopN { get; set; } = 3;
+    [UserField(display:"Recent window (days)")] public int WindowDays { get; set; } = 14;
 }
 
 [IsConfigurable("tool.prs.report")]
 public sealed class PRsReportTool : ITool
 {
-    public string Description => "Manager report — counts per IC, oldest stale list per IC (LLM-free + optional summary).";
-    public string Usage       => "PRsReport({ \"ProfileName\":\"Deployment\", \"TopN\":3 })";
+    public string Description => "Manager report — recent window: counts per IC + linkable bullets with brief descriptions.";
+    public string Usage       => "PRsReport({ \"ProfileName\":\"Deployment\", \"WindowDays\":14 })";
     public Type   InputType   => typeof(ReportPRsInput);
-    public string InputSchema => "{\"type\":\"object\",\"properties\":{\"ProfileName\":{\"type\":\"string\"},\"TopN\":{\"type\":\"integer\"}},\"required\":[\"ProfileName\"]}";
+    public string InputSchema => "{\"type\":\"object\",\"properties\":{\"ProfileName\":{\"type\":\"string\"},\"WindowDays\":{\"type\":\"integer\"}},\"required\":[\"ProfileName\"]}";
 
     public async Task<ToolResult> InvokeAsync(object input, Context ctx)
     {
@@ -71,40 +71,87 @@ public sealed class PRsReportTool : ITool
         if (profile is null) return ToolResult.Failure($"No PRs Profile named '{p.ProfileName}'.", ctx);
 
         var prs = Program.SubsystemManager.Get<PRsClient>();
-        var (cols, rows) = await prs.FetchAsync(profile);
+        var table = await prs.FetchAsync(profile);
 
         // Column ordinals
-        int iCat = cols.Col("Category"), iName = cols.Col("CreatedByDisplayName"), iTitle = cols.Col("Title");
-        int iLink = cols.Col("Link"), iCreated = cols.Col("CreationDate"), iClosed = cols.Col("ClosedDate"), iAge = cols.Col("AgeDays");
+        int iCat = table.Col("Category"),
+            iName = table.Col("CreatedByDisplayName"),
+            iTitle = table.Col("Title"),
+            iLink = table.Col("Link"),
+            iCreated = table.Col("CreationDate"),
+            iClosed = table.Col("ClosedDate"),
+            iAge = table.Col("AgeDays"),
+            iDesc = table.Col("Description"); // present in KQL
 
-        var items = rows.Select(r => new {
-            Category = r[iCat], Name = r[iName], Title = r[iTitle], Link = r[iLink], Created = r[iCreated], Closed = r[iClosed], Age = r[iAge]
+        var items = table.Rows.Select(r => new {
+            Category = r[iCat],
+            Name     = r[iName],
+            Title    = r[iTitle],
+            Link     = r[iLink],
+            Created  = r[iCreated],
+            Closed   = r[iClosed],
+            Age      = r[iAge],
+            Desc     = iDesc >= 0 ? r[iDesc] : string.Empty
         }).ToList();
 
-        var byIC = items.GroupBy(x => x.Name).OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase).ToList();
+        // Build all ICs (stable roster), then compute recent-window counts per IC
+        var allICs = items.GroupBy(x => x.Name)
+                          .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)
+                          .Select(g => g.Key)
+                          .ToList();
+
+        var cutoff = DateTime.UtcNow.AddDays(-Math.Max(1, p.WindowDays));
+        static DateTime Parse(string s) => DateTime.TryParse(s, out var d) ? d : DateTime.MinValue;
+        bool InWindow(string created, string closed)
+            => Parse(created) >= cutoff || Parse(closed) >= cutoff;
+
+        var recent = items.Where(it => InWindow(it.Created, it.Closed)).ToList();
 
         var sb = new StringBuilder();
-        sb.AppendLine("Manager Briefing (counts per IC):");
-        foreach (var g in byIC)
+        sb.AppendLine($"Manager Briefing (counts per IC — last {Math.Max(1, p.WindowDays)}d):");
+        foreach (var icName in allICs)
         {
-            int stale = g.Count(x => x.Category == "stale");
-            int fresh = g.Count(x => x.Category == "new");
+            var g = recent.Where(x => x.Name == icName);
+            int stale  = g.Count(x => x.Category == "stale");
+            int fresh  = g.Count(x => x.Category == "new");
             int closed = g.Count(x => x.Category == "closed");
-            sb.AppendLine($"- {g.Key}: {stale} stale, {fresh} new, {closed} closed (30d)");
+            sb.AppendLine($"- {icName}: {stale} stale, {fresh} new, {closed} closed ({Math.Max(1,p.WindowDays)}d)");
         }
         sb.AppendLine();
 
-        // Oldest stale per IC
-        sb.AppendLine($"Oldest stale per IC (top {Math.Max(1, p.TopN)}):");
-        foreach (var g in byIC)
+        // Bulleted, most-recent PRs (created or closed in-window) per IC
+        foreach (var icName in allICs)
         {
-            var stale = g.Where(x => x.Category == "stale")
-                         .OrderBy(x => DateTime.TryParse(x.Created, out var d) ? d : DateTime.MaxValue)
-                         .Take(Math.Max(1, p.TopN))
-                         .ToList();
-            if (stale.Count == 0) continue;
-            sb.AppendLine($"{g.Key}:");
-            foreach (var s in stale) sb.AppendLine($"  • {s.Created[..10]} — {Utilities.TruncatePlain(s.Title, 110)} → {s.Link}");
+            sb.AppendLine($"## {icName}:");
+
+            var ordered = recent
+                .Where(x => x.Name == icName)
+                .Select(x => new {
+                    x.Category, x.Title, x.Link, x.Desc,
+                    Created = Parse(x.Created), Closed = Parse(x.Closed)
+                })
+                .OrderByDescending(x => (x.Closed > x.Created ? x.Closed : x.Created))
+                .ToList();
+
+            if (ordered.Count == 0)
+            {
+                sb.AppendLine("  (no recent PRs in window)");
+                continue;
+            }
+
+            foreach (var s in ordered)
+            {
+                var date = (s.Closed > s.Created ? s.Closed : s.Created);
+                var when = date == DateTime.MinValue ? "" : date.ToString("yyyy-MM-dd");
+                var title = Utilities.TruncatePlain(s.Title ?? string.Empty, 110);
+                var desc = Utilities.TruncatePlain(string.IsNullOrWhiteSpace(s.Desc) ? s.Title : s.Desc, 140);
+                sb.AppendLine($"--------------------------------------------");
+                sb.AppendLine($"### {when} [{s.Category}] — {title} ");
+                sb.AppendLine(s.Link);
+                sb.AppendLine($"----[DESCRIPTION]---------------------------");
+                sb.AppendLine(desc);
+                sb.AppendLine();
+            }
         }
 
         var output = sb.ToString();
@@ -137,11 +184,14 @@ public sealed class PRsSliceTool : ITool
             .FirstOrDefault(x => x.Name.Equals(p.ProfileName, StringComparison.OrdinalIgnoreCase));
         if (profile is null) return ToolResult.Failure($"No PRs Profile named '{p.ProfileName}'.", ctx);
 
-        var prs = Program.SubsystemManager.Get<PRsClient>();
-        var (cols, rows) = await prs.FetchAsync(profile);
+    var prs = Program.SubsystemManager.Get<PRsClient>();
+    var table = await prs.FetchAsync(profile);
 
-        int iCat = cols.Col("Category"), iTitle = cols.Col("Title"), iLink = cols.Col("Link"), iCreated = cols.Col("CreationDate");
-        var filtered = rows.Where(r => string.Equals(r[iCat], p.Slice, StringComparison.OrdinalIgnoreCase))
+    int iCat = table.Col("Category"), iTitle = table.Col("Title"), iLink = table.Col("Link"), iCreated = table.Col("CreationDate");
+    // Use Table.Slice to exclude rows whose Category does not match the requested slice.
+    var filteredTable = table.Slice((col, val) => string.Equals(col, "Category", StringComparison.OrdinalIgnoreCase)
+                                                        && !string.Equals(val, p.Slice, StringComparison.OrdinalIgnoreCase));
+    var filtered = filteredTable.Rows
                            .OrderBy(r => DateTime.TryParse(r[iCreated], out var d) ? d : DateTime.MaxValue)
                            .Take(Math.Max(1, p.Limit))
                            .ToList();
@@ -157,10 +207,12 @@ public sealed class PRsSliceTool : ITool
         if (!string.IsNullOrWhiteSpace(p.Export))
         {
             var ext = Path.GetExtension(p.Export).ToLowerInvariant();
+            // Build a small Table for export using same headers
+            var exportTable = new Table(table.Headers, filtered.ToList());
             var content = ext switch
             {
-                ".csv"  => Utilities.ToCsv(cols, filtered),
-                ".json" => Utilities.ToJson(cols, filtered),
+                ".csv"  => exportTable.ToCsv(),
+                ".json" => exportTable.ToJson(),
                 _       => output
             };
             File.WriteAllText(p.Export!, content);
@@ -180,7 +232,7 @@ public sealed class CoachPRsInput
 [IsConfigurable("tool.prs.coach")]
 public sealed class PRsCoachTool : ITool
 {
-    public string Description => "Pull ADO PR threads (oldest stale first per IC) and produce coaching suggestions.";
+    public string Description => "Pull ADO PR threads (newest first per IC) and produce attributed, linkable coaching suggestions.";
     public string Usage       => "PRsCoach({ \"ProfileName\":\"Deployment\", \"MaxPerIC\":2 })";
     public Type   InputType   => typeof(CoachPRsInput);
     public string InputSchema => "{\"type\":\"object\",\"properties\":{\"ProfileName\":{\"type\":\"string\"},\"MaxPerIC\":{\"type\":\"integer\"}},\"required\":[\"ProfileName\"]}";
@@ -193,39 +245,33 @@ public sealed class PRsCoachTool : ITool
         if (profile is null) return ToolResult.Failure($"No PRs Profile named '{p.ProfileName}'.", ctx);
 
         var prs = Program.SubsystemManager.Get<PRsClient>();
-        var (cols, rows) = await prs.FetchAsync(profile);
+        var table = await prs.FetchAsync(profile);
 
-        int iCat = cols.Col("Category"), iName = cols.Col("CreatedByDisplayName");
-        int iOrg = cols.Col("OrganizationName"), iProj = cols.Col("RepositoryProjectName"), iRepo = cols.Col("RepositoryName"), iId = cols.Col("PullRequestId"), iCreated = cols.Col("CreationDate");
-        int iLink = cols.Col("Link");
+        // Column ordinals we’ll need (from the unified KQL)
+        int iCat  = table.Col("Category"),
+            iName = table.Col("CreatedByDisplayName"),
+            iAuth = table.Col("CreatedByUniqueName"),
+            iOrg  = table.Col("OrganizationName"),
+            iProj = table.Col("RepositoryProjectName"),
+            iRepo = table.Col("RepositoryName"),
+            iId   = table.Col("PullRequestId"),
+            iLink = table.Col("Link"),
+            iCreated = table.Col("CreationDate");
 
-        // Build per-IC picks (oldest first) – prefer stale, fall back to new
-        var perIc = rows.Where(r => r[iCat] == "stale")
-                        .GroupBy(r => r[iName])
-                        .ToDictionary(g => g.Key, g => g.OrderBy(r => DateTime.TryParse(r[iCreated], out var d) ? d : DateTime.MaxValue)
-                                                        .Take(Math.Max(1, p.MaxPerIC))
-                                                        .Select(r => (Org: r[iOrg], Proj: r[iProj], Repo: r[iRepo], Id: int.Parse(r[iId]), Link: iLink >= 0 ? r[iLink] : string.Empty))
-                                                        .ToList());
-
-        // Fallback to “new” if there are no stale PRs at all
-        if (perIc.Count == 0)
-        {
-            perIc = rows.Where(r => r[iCat] == "new")
-                        .GroupBy(r => r[iName])
-                        .ToDictionary(g => g.Key, g => g.OrderBy(r => DateTime.TryParse(r[iCreated], out var d) ? d : DateTime.MaxValue)
-                                                        .Take(Math.Max(1, p.MaxPerIC))
-                                                        .Select(r => (Org: r[iOrg], Proj: r[iProj], Repo: r[iRepo], Id: int.Parse(r[iId]), Link: iLink >= 0 ? r[iLink] : string.Empty))
-                                                        .ToList());
-        }
+        // Choose newest-first per IC: prefer "new", else "stale", else "closed"
+        Dictionary<string, List<(string Org,string Proj,string Repo,int Id,string Link,string AuthorUnique,DateTime Created)>> perIc = SelectNewest(table, "new");
+    if (perIc.Count == 0) perIc = SelectNewest(table, "stale");
+    if (perIc.Count == 0) perIc = SelectNewest(table, "closed");
 
         var ado = Program.SubsystemManager.Get<AdoClient>();
         var sb = new StringBuilder();
         sb.AppendLine("Coaching Hints (by IC):");
 
         int printed = 0;
-        foreach (var kv in perIc)
+        foreach (var kv in perIc.OrderBy(k => k.Key, StringComparer.OrdinalIgnoreCase))
         {
-            var ic = kv.Key; var picks = kv.Value;
+            var ic = kv.Key;
+            var picks = kv.Value;
             var bullets = new List<string>();
 
             foreach (var pr in picks)
@@ -233,68 +279,8 @@ public sealed class PRsCoachTool : ITool
                 List<GitPullRequestCommentThread> threads;
                 try
                 {
-                    threads = await ado.GetThreadsAsync(pr.Proj, pr.Repo, pr.Id);
-                    
-                    // Build a few concrete, actionable examples with discussion URLs
-                    var examples = new List<string>();
-
-                    IEnumerable<(int ThreadId, string Snippet)> PickExamples()
-                    {
-                        // Flatten comments with their thread id
-                        var all = threads
-                            .SelectMany(t => (t.Comments ?? new List<Comment>()).Select(c => new { t.Id, c.Content }))
-                            .Where(x => !string.IsNullOrWhiteSpace(x.Content));
-
-                        // Light-weight keyword buckets to find representative, actionable examples
-                        var buckets = new (string Tag, string[] Keys)[]
-                        {
-                            ("tests", new[] {"test", "unit", "coverage", "flaky"}),
-                            ("size",  new[] {"too big", "scope", "split", "refactor"}),
-                            ("ci",    new[] {"CI", "build", "pipeline", "fail", "flake"}),
-                            ("perf",  new[] {"perf", "latency", "alloc", "hot path"}),
-                            ("docs",  new[] {"doc", "comment", "readme", "description"}),
-                            ("style", new[] {"nit", "style", "naming", "format", "convention"}),
-                            ("merge", new[] {"merge conflict", "rebase", "out of date"})
-                        };
-
-                        // score each comment by bucket
-                        var scored = all.Select(x =>
-                        {
-                            var lower = x.Content.ToLowerInvariant();
-                            var (tag, score) = buckets
-                                .Select(b => (b.Tag, Score: b.Keys.Count(k => lower.Contains(k.ToLowerInvariant()))))
-                                .OrderByDescending(t => t.Score)
-                                .FirstOrDefault();
-                            return new { x.Id, x.Content, tag, score };
-                        })
-                        .Where(s => s.score > 0);
-
-                        // take top few distinct tags to avoid redundancy
-                        var picked = scored
-                            .GroupBy(s => s.tag)
-                            .OrderByDescending(g => g.Max(s => s.score))
-                            .Take(3)
-                            .Select(g =>
-                            {
-                                var best = g.OrderByDescending(s => s.score).First();
-                                var snippet = Utilities.TruncatePlain(best.Content.Replace("\r", " ").Replace("\n", " "), 160);
-                                return (ThreadId: best.Id, Snippet: snippet);
-                            });
-
-                        return picked;
-                    }
-
-                    foreach (var ex in PickExamples())
-                    {
-                        var tUrl = AdoClient.BuildDiscussionUrl(pr.Org, pr.Proj, pr.Repo, pr.Id, ex.ThreadId);
-                        examples.Add($"- \"{ex.Snippet}\"  \n    ↳ {tUrl}");
-                    }
-
-                    if (examples.Count > 0)
-                    {
-                        bullets.Add("Examples:\n" + string.Join("\n", examples) + "\n");
-                    }
-
+                    // Pull all comment threads for this PR
+                    threads = await ado.GetPullRequestThreadsAsync(pr.Proj, pr.Repo, pr.Id);
                 }
                 catch (Exception ex)
                 {
@@ -302,31 +288,117 @@ public sealed class PRsCoachTool : ITool
                     continue;
                 }
 
-                var text = string.Join("\n", threads
-                    .SelectMany(t => t.Comments?.Select(c => c.Content) ?? Enumerable.Empty<string>())
-                    .Where(s => !string.IsNullOrWhiteSpace(s)));
+                // Partition comments into "received" (others -> IC) and "given" (IC -> others).
+                var received = new List<(int ThreadId, string Who, string Content)>();
+                var given    = new List<(int ThreadId, string Who, string Content)>();
 
-                if (string.IsNullOrWhiteSpace(text))
+                foreach (var t in threads)
                 {
-                    bullets.Add($"PR {pr.Id}: no review comments yet.");
-                    continue;
+                    var comments = t.Comments ?? new List<Comment>();
+                    foreach (var c in comments)
+                    {
+                        if (string.IsNullOrWhiteSpace(c.Content)) continue;
+
+                        var whoUnique  = c.Author?.UniqueName ?? "";
+                        var whoDisplay = !string.IsNullOrWhiteSpace(c.Author?.DisplayName) ? c.Author!.DisplayName
+                                        : (!string.IsNullOrWhiteSpace(whoUnique) ? whoUnique : "Reviewer");
+
+                        // Heuristic: downrank/skip AI boilerplate comments
+                        bool looksAI = LooksAI(c.Content);
+
+                        if (!string.IsNullOrWhiteSpace(pr.AuthorUnique) &&
+                            whoUnique.Equals(pr.AuthorUnique, StringComparison.OrdinalIgnoreCase))
+                        {
+                            // Author of PR
+                            if (!looksAI) given.Add((t.Id, whoDisplay, c.Content));
+                        }
+                        else
+                        {
+                            // Reviewers (received feedback)
+                            if (!looksAI) received.Add((t.Id, whoDisplay, c.Content));
+                        }
+                    }
                 }
 
-                var prompt = @"""
-You are an EM reviewing PR review threads. Summarize the recurring coaching themes in 3-5 bullets. Use short, actionable language.
-Focus areas to look for: test coverage, build/CI issues, PR size/scope, unclear descriptions, style/nits churn, rebase/merge conflicts, perf concerns, ownership or responsiveness.
-Output only bullets (no preamble). """ + "\n\n" + Utilities.TruncatePlain(text, 4000);
+                // If we filtered everything away as AI, allow a tiny fallback so the section isn't empty
+                if (received.Count == 0)
+                {
+                    var any = threads.SelectMany(t => (t.Comments ?? new List<Comment>())
+                                  .Where(c => !string.IsNullOrWhiteSpace(c.Content))
+                                  .Select(c => (ThreadId: t.Id,
+                                                Who: c.Author?.DisplayName ?? c.Author?.UniqueName ?? "Reviewer",
+                                                Content: c.Content)))
+                                  .Where(x => string.IsNullOrWhiteSpace(pr.AuthorUnique) ||
+                                              !string.Equals(x.Who, pr.AuthorUnique, StringComparison.OrdinalIgnoreCase))
+                                  .Take(2);
+                    received.AddRange(any);
+                }
+                if (given.Count == 0)
+                {
+                    var any = threads.SelectMany(t => (t.Comments ?? new List<Comment>())
+                                  .Where(c => !string.IsNullOrWhiteSpace(c.Content) &&
+                                              string.Equals(c.Author?.UniqueName ?? "", pr.AuthorUnique ?? "",
+                                                            StringComparison.OrdinalIgnoreCase))
+                                  .Select(c => (ThreadId: t.Id,
+                                                Who: c.Author?.DisplayName ?? c.Author?.UniqueName ?? "Author",
+                                                Content: c.Content)))
+                                  .Take(2);
+                    given.AddRange(any);
+                }
 
-                var summary = await Engine.Provider!.PostChatAsync(new Context(prompt), 0.2f);
+                // Pick representative examples (by “bucket” keywords) for received/given
+                var recvExamples = PickExamples(received);
+                var gaveExamples = PickExamples(given);
 
+                // Build per-PR coaching summary for received/given feedback
+                string recvThemes = SummarizeThemes(recvExamples.Select(e => e.Content));
+                string gaveThemes = SummarizeThemes(gaveExamples.Select(e => e.Content), focusOnReviewerStyle:true);
+
+                // PR URL in header (use Link from KQL; fallback to builder)
                 var prUrl = !string.IsNullOrWhiteSpace(pr.Link)
                     ? pr.Link
                     : AdoClient.BuildPullRequestUrl(pr.Org, pr.Proj, pr.Repo, pr.Id);
 
-                bullets.Add($"PR {pr.Id} — {prUrl}:\n{summary.Trim()}\n");
+                var block = new StringBuilder();
+                block.AppendLine($"PR {pr.Id} — {prUrl}");
+
+                if (!string.IsNullOrWhiteSpace(recvThemes))
+                {
+                    block.AppendLine("  Feedback on your PRs — themes:");
+                    foreach (var line in recvThemes.Split('\n').Where(s => !string.IsNullOrWhiteSpace(s)))
+                        block.AppendLine("  - " + line.Trim());
+                }
+                if (!string.IsNullOrWhiteSpace(gaveThemes))
+                {
+                    block.AppendLine("  Feedback you wrote — themes:");
+                    foreach (var line in gaveThemes.Split('\n').Where(s => !string.IsNullOrWhiteSpace(s)))
+                        block.AppendLine("  - " + line.Trim());
+                }
+
+                // Examples: received (reviewers) first, then given (author)
+                if (recvExamples.Any())
+                {
+                    block.AppendLine("  Examples (what reviewers told you):");
+                    foreach (var ex in recvExamples)
+                    {
+                        var tUrl = AdoClient.BuildDiscussionUrl(pr.Org, pr.Proj, pr.Repo, pr.Id, ex.ThreadId);
+                        block.AppendLine($"    - **{ex.Who}:** \"{Trunc(ex.Content, 160)}\"  \n      ↳ {tUrl}");
+                    }
+                }
+                if (gaveExamples.Any())
+                {
+                    block.AppendLine("  Examples (feedback you wrote):");
+                    foreach (var ex in gaveExamples)
+                    {
+                        var tUrl = AdoClient.BuildDiscussionUrl(pr.Org, pr.Proj, pr.Repo, pr.Id, ex.ThreadId);
+                        block.AppendLine($"    - **{ex.Who}:** \"{Trunc(ex.Content, 160)}\"  \n      ↳ {tUrl}");
+                    }
+                }
+
+                bullets.Add(block.ToString());
             }
 
-            // Always print the IC header; show “no items” if needed
+            // IC header + bullets (or “no items”)
             sb.AppendLine($"{ic}:");
             if (bullets.Count == 0)
             {
@@ -339,27 +411,129 @@ Output only bullets (no preamble). """ + "\n\n" + Utilities.TruncatePlain(text, 
             }
         }
 
-        // If nothing at all was printed, add a friendly note
         if (printed == 0)
         {
-            sb.AppendLine("No stale or new PRs with review discussion were found for this profile and window.");
+            sb.AppendLine("No relevant PRs with review discussion were found for this profile and window.");
         }
 
         var output = sb.ToString();
         ctx.AddToolMessage(output);
         await ContextManager.AddContent(output, $"prs/{profile.Name}/coach");
         return ToolResult.Success(output, ctx);
+
+        // ===== local helpers =====
+
+        Dictionary<string, List<(string Org,string Proj,string Repo,int Id,string Link,string AuthorUnique,DateTime Created)>> SelectNewest(Table srcTable, string category)
+        {
+            // Exclude rows whose Category does not match the requested category using Table.Slice.
+            var sliced = srcTable.Slice((col, val) => string.Equals(col, "Category", StringComparison.OrdinalIgnoreCase)
+                                                           && !string.Equals(val, category, StringComparison.OrdinalIgnoreCase));
+            return sliced.Rows
+                       .GroupBy(r => r[iName])
+                       .ToDictionary(
+                           g => g.Key,
+                           g => g.OrderByDescending(r => DateTime.TryParse(r[iCreated], out var d) ? d : DateTime.MinValue)
+                                 .Take(Math.Max(1, p.MaxPerIC))
+                                 .Select(r => (
+                                     Org:  r[iOrg],
+                                     Proj: r[iProj],
+                                     Repo: r[iRepo],
+                                     Id:   int.TryParse(r[iId], out var idv) ? idv : 0,
+                                     Link: iLink >= 0 ? r[iLink] : string.Empty,
+                                     AuthorUnique: iAuth >= 0 ? r[iAuth] : string.Empty,
+                                     Created: DateTime.TryParse(r[iCreated], out var d) ? d : DateTime.MinValue))
+                                 .ToList());
+        }
+
+        static bool LooksAI(string content)
+        {
+            var s = content.Trim().ToLowerInvariant();
+            // crude but effective filters for AI boilerplate
+            return s.Contains("ai description") ||
+                   s.Contains("generated by") ||
+                   s.Contains("copilot") ||
+                   s.Contains("chatgpt") ||
+                   s.StartsWith("ai:") ||
+                   s.StartsWith("[ai]");
+        }
+
+        static string Trunc(string s, int n)
+        {
+            var t = s.Replace("\r", " ").Replace("\n", " ");
+            if (t.Length <= n) return t;
+            return t.Substring(0, Math.Max(0, n - 1)) + "…";
+        }
+
+        // Score comments by lightweight buckets to pick representative examples
+        static IEnumerable<(int ThreadId, string Who, string Content)> PickExamples(IEnumerable<(int ThreadId, string Who, string Content)> items)
+        {
+            var buckets = new (string Tag, string[] Keys)[] {
+                ("tests", new[] {"test", "unit", "coverage", "flaky"}),
+                ("size",  new[] {"too big", "scope", "split", "refactor"}),
+                ("ci",    new[] {"ci", "build", "pipeline", "fail", "flake"}),
+                ("perf",  new[] {"perf", "latency", "alloc", "hot path"}),
+                ("docs",  new[] {"doc", "comment", "readme", "description"}),
+                ("style", new[] {"nit", "style", "naming", "format", "convention"}),
+                ("merge", new[] {"merge conflict", "rebase", "out of date"})
+            };
+
+            var scored = items.Select(x => {
+                                var lower = x.Content.ToLowerInvariant();
+                                var (tag, score) = buckets
+                                    .Select(b => (b.Tag, Score: b.Keys.Count(k => lower.Contains(k))))
+                                    .OrderByDescending(t => t.Score)
+                                    .FirstOrDefault();
+                                return (x.ThreadId, x.Who, x.Content, tag, score);
+                            })
+                            .Where(s => s.score > 0);
+
+            if (scored.Any())
+            {
+                return scored.GroupBy(s => s.tag)
+                             .OrderByDescending(g => g.Max(s => s.score))
+                             .Take(3)
+                             .Select(g => {
+                                 var best = g.OrderByDescending(s => s.score).First();
+                                 return (best.ThreadId, best.Who, best.Content);
+                             });
+            }
+
+            // Fallback: first few raw comments
+            return items.Take(3);
+        }
+
+        // Summarize themes deterministically; if model available, use it; else simple heuristics
+        string SummarizeThemes(IEnumerable<string> comments, bool focusOnReviewerStyle = false)
+        {
+            var text = string.Join("\n", comments.Where(s => !string.IsNullOrWhiteSpace(s)));
+            if (string.IsNullOrWhiteSpace(text)) return "";
+
+            try
+            {
+                var prompt = focusOnReviewerStyle
+                    ? "You are an EM reviewing how an engineer gives feedback in PRs. In 3–5 bullets, summarize strengths and improvement areas in their review comments. Prefer concrete, actionable guidance. Output only bullets."
+                    : "You are an EM coaching an engineer based on review feedback they received on their PRs. In 3–5 bullets, summarize recurring themes with actionable guidance. Output only bullets.";
+                var summary = Engine.Provider!.PostChatAsync(new Context(prompt + "\n\n" + Utilities.TruncatePlain(text, 4000)), 0.2f).GetAwaiter().GetResult();
+                return summary.Trim();
+            }
+            catch
+            {
+                // Non-LLM fallback: keyword tallies → bullets
+                var l = text.ToLowerInvariant();
+                var bullets = new List<string>();
+                if (l.Contains("test")) bullets.Add("Increase test coverage and include edge cases.");
+                if (l.Contains("nit") || l.Contains("style")) bullets.Add("Reduce style/nit churn; batch fixes and follow guidelines.");
+                if (l.Contains("rebase") || l.Contains("merge")) bullets.Add("Rebase regularly to avoid merge conflicts.");
+                if (l.Contains("perf")) bullets.Add("Watch for perf risk in hot paths.");
+                if (l.Contains("ci") || l.Contains("build")) bullets.Add("Keep CI/build green; address failures promptly.");
+                return string.Join("\n", bullets);
+            }
+        }
     }
 }
 
-
 public static class PrsExtensions
 {
-    // Thin wrapper since GitHttpClient is already initialized in AdoClient; keep the public method here to avoid exposing internals.
-    public static async Task<List<GitPullRequestCommentThread>> GetThreadsAsync(this AdoClient ado, string project, string repoName, int prId)
-        => await ado.GetPullRequestThreadsAsync(project, repoName, prId);
-
     public static int Col(this IReadOnlyList<string> cols, string name) =>
         cols.Select((c, i) => new { c, i }).FirstOrDefault(x => string.Equals(x.c, name, StringComparison.OrdinalIgnoreCase))?.i ?? -1;
-
 }

--- a/Subsytems/PRs/PRsTools.cs
+++ b/Subsytems/PRs/PRsTools.cs
@@ -219,7 +219,7 @@ public sealed class PRsSliceTool : ITool
         lines.Add($"Slice: {p.Slice} (limit {p.Limit})");
         foreach (var r in filtered)
         {
-            lines.Add($"- {r.Created:MM/dd/yyyy} — {r.Link} → {Utilities.TruncatePlain(r.Author, 20)} [{r.State}] {Utilities.TruncatePlain(r.Title, 110)}");
+            lines.Add($"- {r.Created:MM/dd/yyyy} — {r.Link} - {Utilities.TruncatePlain(r.Author, 20)} [{r.State}] {Utilities.TruncatePlain(r.Title, 110)}");
         }
         var output = string.Join("\n", lines);
 

--- a/Subsytems/S360/S360Client.cs
+++ b/Subsytems/S360/S360Client.cs
@@ -78,7 +78,7 @@ S360Id = ID, URL, ServiceId, AssignedTo, DelegatedAssignedTo, KpiDescriptionHtml
 | order by ServiceName asc, KpiTitle asc, ActionItemTitle asc, CurrentETA, CurrentDueDate";
     }
 
-    public async Task<(IReadOnlyList<string> Cols, List<string[]> Rows)> FetchAsync(S360Profile profile)
+    public async Task<Table> FetchAsync(S360Profile profile)
     {
         var kusto = Program.SubsystemManager.Get<KustoClient>();
         var kql = BuildActionItemsKql(profile.ServiceIds);
@@ -236,9 +236,11 @@ S360Id = ID, URL, ServiceId, AssignedTo, DelegatedAssignedTo, KpiDescriptionHtml
 
     
     public List<(S360Row Row, float Score, Dictionary<string, float> Factors)> Score(
-        IReadOnlyList<string> cols, List<string[]> rows, S360Profile p)
+        Table table, S360Profile p)
     {
-        int C(string name) => Array.FindIndex(cols.ToArray(), c => c.Equals(name, StringComparison.OrdinalIgnoreCase));
+        int C(string name) => table.Col(name);
+        var cols = table.Headers;
+        var rows = table.Rows;
         var idx = new Dictionary<string, int>
         {
             ["ServiceName"] = C("ServiceName"),

--- a/Table.cs
+++ b/Table.cs
@@ -1,6 +1,7 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Collections.Generic;
 
 public sealed class Table
 {
@@ -11,6 +12,57 @@ public sealed class Table
     {
         Headers = headers ?? Array.Empty<string>();
         Rows = rows ?? new List<string[]>();
+    }
+
+    // Factory: construct a Table from an enumerable of T using reflection to derive columns.
+    // For simple/primitive T (string, numeric, DateTime, enum) the table will have a single "Value" column.
+    // For complex types, public instance readable properties (in declaration order via metadata token fallback) are used as columns.
+    public static Table FromEnumerable<T>(IEnumerable<T>? items)
+    {
+        var list = (items == null) ? new List<T>() : items.ToList();
+        if (!list.Any()) return new Table(Array.Empty<string>(), new List<string[]>());
+
+        var t = typeof(T);
+        // Treat primitives, enums, string, decimal, DateTime as scalar values
+        bool isScalar = t.IsPrimitive || t.IsEnum || t == typeof(string) || t == typeof(decimal) || t == typeof(DateTime);
+        if (isScalar)
+        {
+            var rows = list.Select(x => new string[] { x?.ToString() ?? string.Empty }).ToList();
+            return new Table(new List<string> { "Value" }, rows);
+        }
+
+        // Prefer public instance properties that are readable
+        var props = t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                     .Where(p => p.CanRead)
+                     .OrderBy(p => p.MetadataToken)
+                     .ToList();
+
+        // If no properties, fall back to public fields
+        if (props.Count == 0)
+        {
+            var fields = t.GetFields(BindingFlags.Public | BindingFlags.Instance)
+                          .OrderBy(f => f.MetadataToken)
+                          .ToList();
+            if (fields.Count > 0)
+            {
+                var headers = fields.Select(f => f.Name).ToList();
+                var rows = list.Select(x => fields.Select(f => {
+                    var v = f.GetValue(x);
+                    return v?.ToString() ?? string.Empty;
+                }).ToArray()).ToList();
+                return new Table(headers, rows);
+            }
+            // Nothing to reflect; treat as single value
+            var scalarRows = list.Select(x => new string[] { x?.ToString() ?? string.Empty }).ToList();
+            return new Table(new List<string> { "Value" }, scalarRows);
+        }
+
+        var headers2 = props.Select(p => p.Name).ToList();
+        var rows2 = list.Select(x => props.Select(p => {
+            try { var v = p.GetValue(x); return v?.ToString() ?? string.Empty; }
+            catch { return string.Empty; }
+        }).ToArray()).ToList();
+        return new Table(headers2, rows2);
     }
 
     public int Col(string name)
@@ -112,23 +164,18 @@ public sealed class Table
         return new Table(newHeaders, newRows);
     }
 
-    // Return a new table where rows are filtered by the predicate which examines each (columnName, cellValue).
-    // The predicate should return true if the row should be excluded for a given (columnName, cellValue).
-    // A row is excluded if the predicate returns true for any column in that row.
-    public Table Slice(Func<string, string, bool> excludeRowPredicate)
+    // Exclude rows where the predicate returns true for the specified column's value.
+    public Table Slice(string columnName, Func<string, bool> valuePredicate)
     {
-        if (excludeRowPredicate == null) return new Table(Headers, Rows.Select(r => r.ToArray()).ToList());
+        if (string.IsNullOrWhiteSpace(columnName) || valuePredicate == null)
+            return new Table(Headers, Rows.Select(r => r.ToArray()).ToList());
+        int idx = Col(columnName);
+        if (idx < 0) return new Table(Headers, Rows.Select(r => r.ToArray()).ToList());
         var newRows = new List<string[]>();
         foreach (var r in Rows)
         {
-            bool exclude = false;
-            for (int i = 0; i < Headers.Count; i++)
-            {
-                var colName = Headers[i];
-                var val = i < r.Length ? r[i] ?? string.Empty : string.Empty;
-                if (excludeRowPredicate(colName, val)) { exclude = true; break; }
-            }
-            if (!exclude) newRows.Add(r.ToArray());
+            var val = (idx < r.Length) ? (r[idx] ?? string.Empty) : string.Empty;
+            if (!valuePredicate(val)) newRows.Add(r.ToArray());
         }
         return new Table(Headers.ToList(), newRows);
     }
@@ -152,5 +199,115 @@ public sealed class Table
             return o;
         }).ToList();
         return list.ToJson();
+    }
+
+    // Return indices for the requested column names (in same order)
+    public int[] Indices(params string[] names)
+        => names.Select(n => Col(n)).ToArray();
+
+    // Return a function that given a column name returns the cell value for the provided row (empty string if missing)
+    public Func<string, string> Accessor(string[] row)
+    {
+        return name => {
+            var idx = Col(name);
+            return (idx >= 0 && idx < row.Length) ? (row[idx] ?? string.Empty) : string.Empty;
+        };
+    }
+
+    // Project rows using a projector that receives a per-row accessor (name -> value).
+    public IEnumerable<T> SelectRows<T>(Func<Func<string, string>, T> projector)
+        => Rows.Select(r => projector(Accessor(r))).ToList();
+
+    // Order the table by a specified column using a key selector that converts the cell string to a comparable key.
+    public Table OrderBy<TKey>(string columnName, Func<string, TKey> keySelector, bool descending = false) where TKey : IComparable
+    {
+        if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+        int idx = Col(columnName);
+        IEnumerable<string[]> ordered;
+        if (descending)
+        {
+            ordered = Rows.OrderByDescending(r => {
+                try {
+                    return (idx >= 0 && idx < r.Length) ? keySelector(r[idx] ?? string.Empty) : default(TKey)!;
+                } catch { return default(TKey)!; }
+            });
+        }
+        else
+        {
+            ordered = Rows.OrderBy(r => {
+                try {
+                    return (idx >= 0 && idx < r.Length) ? keySelector(r[idx] ?? string.Empty) : default(TKey)!;
+                } catch { return default(TKey)!; }
+            });
+        }
+        var rowsOut = ordered.Select(r => r.ToArray()).ToList();
+        return new Table(Headers.ToList(), rowsOut);
+    }
+
+    // Convenience: order lexicographically by the column (string comparison).
+    public Table OrderBy(string columnName, bool descending = false)
+        => OrderBy<string>(columnName, s => s ?? string.Empty, descending);
+
+    // Return a new table with only the first `count` rows (or all rows if count >= row count)
+    public Table Take(int count)
+    {
+        if (count <= 0) return new Table(Headers.ToList(), new List<string[]>());
+        var rowsOut = Rows.Take(count).Select(r => r.ToArray()).ToList();
+        return new Table(Headers.ToList(), rowsOut);
+    }
+
+    // Generic grouping: project each row (via an accessor) into T and group by the group column value.
+    public Dictionary<string, List<T>> GroupRowsBy<T>(string groupColumn, Func<Func<string, string>, T> projector)
+    {
+        if (projector == null) throw new ArgumentNullException(nameof(projector));
+        int gidx = Col(groupColumn);
+        var result = new Dictionary<string, List<T>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var r in Rows)
+        {
+            var g = (gidx >= 0 && gidx < r.Length) ? (r[gidx] ?? string.Empty) : string.Empty;
+            if (!result.TryGetValue(g, out var list)) { list = new List<T>(); result[g] = list; }
+            var acc = Accessor(r);
+            var obj = projector(acc);
+            list.Add(obj);
+        }
+        return result;
+    }
+
+    // Return a new table containing the newest N rows per group (grouped by groupColumn).
+    // selectColumns defines which columns to include in the output (in addition to the group column).
+    // dateColumn is used to order within each group (newest first). If a date cannot be parsed it is treated as MinValue.
+    public Table LatestPerGroup(string groupColumn, string categoryColumn, string categoryValue, string dateColumn, int perGroup, IEnumerable<string> selectColumns)
+    {
+    // Filter by category using the column-based Slice overload
+    var filtered = this.Slice(categoryColumn, val => !string.Equals(val, categoryValue, StringComparison.OrdinalIgnoreCase));
+
+        int igroup = filtered.Col(groupColumn);
+        int idate = filtered.Col(dateColumn);
+        var selectList = (selectColumns ?? Enumerable.Empty<string>()).ToList();
+        var selIndices = selectList.Select(c => filtered.Col(c)).ToList();
+
+        var rowsOut = new List<string[]>();
+        foreach (var g in filtered.Rows.GroupBy(r => (igroup >= 0 && igroup < r.Length) ? r[igroup] : string.Empty))
+        {
+            var ordered = g.OrderByDescending(r => {
+                if (idate >= 0 && idate < r.Length && DateTime.TryParse(r[idate], out var d)) return d;
+                return DateTime.MinValue;
+            }).Take(Math.Max(1, perGroup));
+
+            foreach (var r in ordered)
+            {
+                var row = new List<string> { g.Key };
+                for (int i = 0; i < selIndices.Count; i++)
+                {
+                    var idx = selIndices[i];
+                    row.Add(idx >= 0 && idx < r.Length ? r[idx] : string.Empty);
+                }
+                rowsOut.Add(row.ToArray());
+            }
+        }
+
+        var headers = new List<string> { groupColumn };
+        headers.AddRange(selectList);
+        return new Table(headers, rowsOut);
     }
 }

--- a/Table.cs
+++ b/Table.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public sealed class Table
+{
+    public IReadOnlyList<string> Headers { get; }
+    public List<string[]> Rows { get; }
+
+    public Table(IReadOnlyList<string> headers, List<string[]> rows)
+    {
+        Headers = headers ?? Array.Empty<string>();
+        Rows = rows ?? new List<string[]>();
+    }
+
+    public int Col(string name)
+        => Headers.Select((c, i) => new { c, i }).FirstOrDefault(x => string.Equals(x.c, name, StringComparison.OrdinalIgnoreCase))?.i ?? -1;
+
+    // Render to console-friendly table string. maxWidth is optional.
+    public string ToText(int maxWidth = 140)
+    {
+        var hs = Headers.ToList();
+        var rowList = Rows.ToList();
+
+        int origCount = hs.Count;
+        var indices = Enumerable.Range(0, origCount).ToList();
+
+        if (rowList.Count > 0)
+        {
+            indices = indices.Where(i => rowList.Any(r => i < r.Length && !string.IsNullOrEmpty(r[i]))).ToList();
+            if (indices.Count == 0) indices = Enumerable.Range(0, origCount).ToList();
+        }
+
+        var maxLens = new List<int>();
+        foreach (var i in indices)
+        {
+            int w = hs[i]?.Length ?? 0;
+            foreach (var r in rowList)
+            {
+                if (i < r.Length && r[i] != null)
+                    w = Math.Max(w, r[i].Length);
+            }
+            maxLens.Add(w);
+        }
+
+        int colCount = indices.Count;
+        if (colCount == 0) return string.Empty;
+
+        int sepWidth = 3 * Math.Max(0, colCount - 1);
+        int contentMax = Math.Max(1, maxWidth - sepWidth);
+
+        int minCol = 6;
+        if (contentMax < colCount * minCol)
+        {
+            minCol = Math.Max(1, contentMax / colCount);
+        }
+
+        var widths = new int[colCount];
+        int allocated = 0;
+        for (int idx = 0; idx < colCount; idx++)
+        {
+            int remaining = colCount - idx - 1;
+            int minForRemaining = remaining * minCol;
+            int availableForThis = contentMax - allocated - minForRemaining;
+            int desired = Math.Min(maxLens[idx], contentMax);
+            int w = Math.Clamp(desired, minCol, Math.Max(minCol, availableForThis));
+            widths[idx] = w;
+            allocated += w;
+        }
+
+        int leftover = contentMax - allocated;
+        for (int i = 0; leftover > 0 && i < colCount; i++)
+        {
+            int add = Math.Min(leftover, Math.Max(0, maxLens[i] - widths[i]));
+            widths[i] += add;
+            leftover -= add;
+        }
+        for (int i = 0; leftover > 0 && i < colCount; i++)
+        {
+            widths[i] += 1;
+            leftover -= 1;
+        }
+
+        string Fit(string s, int w) => (s.Length <= w) ? s.PadRight(w) : s.Substring(0, Math.Max(0, w - 1)) + "…";
+
+        var lines = new List<string>();
+        lines.Add(string.Join(" │ ", indices.Select((origIdx, j) => Fit(hs[origIdx] ?? "", widths[j]))));
+        lines.Add(string.Join("─┼─", widths.Select(c => new string('─', Math.Max(1, c)))));
+
+        foreach (var row in rowList)
+        {
+            var parts = new List<string>();
+            for (int j = 0; j < colCount; j++)
+            {
+                var origIdx = indices[j];
+                var s = (origIdx < row.Length) ? (row[origIdx] ?? "") : "";
+                parts.Add(Fit(s, widths[j]));
+            }
+            lines.Add(string.Join(" │ ", parts));
+        }
+
+        return string.Join("\n", lines);
+    }
+
+    // Return a new table excluding the specified column names (if present)
+    public Table Slice(IEnumerable<string> excludeColumnNames)
+    {
+        var exclude = new HashSet<string>(excludeColumnNames ?? Enumerable.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+        var keepIndices = Headers.Select((h, i) => new { h, i }).Where(x => !exclude.Contains(x.h)).Select(x => x.i).ToList();
+        var newHeaders = keepIndices.Select(i => Headers[i]).ToList();
+        var newRows = Rows.Select(r => keepIndices.Select(i => i < r.Length ? r[i] ?? string.Empty : string.Empty).ToArray()).ToList();
+        return new Table(newHeaders, newRows);
+    }
+
+    // Return a new table where rows are filtered by the predicate which examines each (columnName, cellValue).
+    // The predicate should return true if the row should be excluded for a given (columnName, cellValue).
+    // A row is excluded if the predicate returns true for any column in that row.
+    public Table Slice(Func<string, string, bool> excludeRowPredicate)
+    {
+        if (excludeRowPredicate == null) return new Table(Headers, Rows.Select(r => r.ToArray()).ToList());
+        var newRows = new List<string[]>();
+        foreach (var r in Rows)
+        {
+            bool exclude = false;
+            for (int i = 0; i < Headers.Count; i++)
+            {
+                var colName = Headers[i];
+                var val = i < r.Length ? r[i] ?? string.Empty : string.Empty;
+                if (excludeRowPredicate(colName, val)) { exclude = true; break; }
+            }
+            if (!exclude) newRows.Add(r.ToArray());
+        }
+        return new Table(Headers.ToList(), newRows);
+    }
+
+    public string ToCsv()
+    {
+        static string E(string s) => s.Contains('"') || s.Contains(',') || s.Contains('\n')
+            ? "\"" + s.Replace("\"", "\"\"") + "\"" : s;
+        var lines = new List<string> { string.Join(",", Headers) };
+        lines.AddRange(Rows.Select(r => string.Join(",", r.Select(E))));
+        return string.Join("\n", lines);
+    }
+
+    public string ToJson()
+    {
+        var list = Rows.Select(r =>
+        {
+            var o = new Dictionary<string, object?>();
+            for (int i = 0; i < Headers.Count; i++)
+                o[Headers[i]] = i < r.Length ? r[i] : null;
+            return o;
+        }).ToList();
+        return list.ToJson();
+    }
+}

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -109,124 +109,25 @@ public static class Utilities
 
     internal static string StripRTF(string inputRtf) => RichTextStripper.StripRichTextFormat(inputRtf);
 
-    // Renderer helpers moved from KustoClient
+    // Renderer helpers are now on the Table class. Provide compatibility wrappers.
+    public static Table ToTable(IEnumerable<string> headers, IEnumerable<string[]> rows)
+    {
+        var hs = headers?.ToList() ?? new List<string>();
+        var rs = rows?.ToList() ?? new List<string[]>();
+        return new Table(hs, rs);
+    }
+
     public static string ToTable(IEnumerable<string> headers, IEnumerable<string[]> rows, int maxWidth = 140)
     {
-        var hs = headers.ToList();
-        var rowList = rows.ToList();
-
-        int origCount = hs.Count;
-        var indices = Enumerable.Range(0, origCount).ToList();
-
-        // If we have rows, drop columns where every row value is null/empty (noise).
-        if (rowList.Count > 0)
-        {
-            indices = indices.Where(i => rowList.Any(r => i < r.Length && !string.IsNullOrEmpty(r[i]))).ToList();
-            // If that removed everything, fall back to keeping all columns so we still show headers
-            if (indices.Count == 0) indices = Enumerable.Range(0, origCount).ToList();
-        }
-
-        // Compute max content length per column (header vs cell content)
-        var maxLens = new List<int>();
-        foreach (var i in indices)
-        {
-            int w = hs[i]?.Length ?? 0;
-            foreach (var r in rowList)
-            {
-                if (i < r.Length && r[i] != null)
-                    w = Math.Max(w, r[i].Length);
-            }
-            maxLens.Add(w);
-        }
-
-        int colCount = indices.Count;
-        if (colCount == 0) return string.Empty;
-
-        // Compute available content width (excluding separators " │ " between columns)
-        int sepWidth = 3 * Math.Max(0, colCount - 1);
-        int contentMax = Math.Max(1, maxWidth - sepWidth);
-
-        int minCol = 6;
-        if (contentMax < colCount * minCol)
-        {
-            // Shrink minCol if overall space is limited
-            minCol = Math.Max(1, contentMax / colCount);
-        }
-
-        // Greedy left-to-right allocation: try to give each column its needed width
-        var widths = new int[colCount];
-        int allocated = 0;
-        for (int idx = 0; idx < colCount; idx++)
-        {
-            int remaining = colCount - idx - 1;
-            int minForRemaining = remaining * minCol;
-            int availableForThis = contentMax - allocated - minForRemaining;
-            int desired = Math.Min(maxLens[idx], contentMax);
-            int w = Math.Clamp(desired, minCol, Math.Max(minCol, availableForThis));
-            widths[idx] = w;
-            allocated += w;
-        }
-
-        // If we under-allocated due to clamping, distribute leftover space left-to-right
-        int leftover = contentMax - allocated;
-        for (int i = 0; leftover > 0 && i < colCount; i++)
-        {
-            int add = Math.Min(leftover, Math.Max(0, maxLens[i] - widths[i]));
-            widths[i] += add;
-            leftover -= add;
-        }
-        // If still leftover, give one char per column left-to-right
-        for (int i = 0; leftover > 0 && i < colCount; i++)
-        {
-            widths[i] += 1;
-            leftover -= 1;
-        }
-
-        string Fit(string s, int w) => (s.Length <= w) ? s.PadRight(w) : s.Substring(0, Math.Max(0, w - 1)) + "…";
-
-        var lines = new List<string>();
-
-        // Header
-        lines.Add(string.Join(" │ ", indices.Select((origIdx, j) => Fit(hs[origIdx] ?? "", widths[j]))));
-        // Separator
-        lines.Add(string.Join("─┼─", widths.Select(c => new string('─', Math.Max(1, c)))));
-
-        // Rows
-        foreach (var row in rowList)
-        {
-            var parts = new List<string>();
-            for (int j = 0; j < colCount; j++)
-            {
-                var origIdx = indices[j];
-                var s = (origIdx < row.Length) ? (row[origIdx] ?? "") : "";
-                parts.Add(Fit(s, widths[j]));
-            }
-            lines.Add(string.Join(" │ ", parts));
-        }
-
-        return string.Join("\n", lines);
+        var t = ToTable(headers, rows);
+        return t.ToText(maxWidth);
     }
 
     public static string ToCsv(IReadOnlyList<string> headers, List<string[]> rows)
-    {
-        static string E(string s) => s.Contains('"') || s.Contains(',') || s.Contains('\n')
-            ? "\"" + s.Replace("\"", "\"\"") + "\"" : s;
-        var lines = new List<string> { string.Join(",", headers) };
-        lines.AddRange(rows.Select(r => string.Join(",", r.Select(E))));
-        return string.Join("\n", lines);
-    }
+        => ToTable(headers, rows).ToCsv();
 
     public static string ToJson(IReadOnlyList<string> headers, List<string[]> rows)
-    {
-        var list = rows.Select(r =>
-        {
-            var o = new Dictionary<string, object?>();
-            for (int i = 0; i < headers.Count; i++)
-                o[headers[i]] = i < r.Length ? r[i] : null;
-            return o;
-        }).ToList();
-        return list.ToJson();
-    }
+        => ToTable(headers, rows).ToJson();
 
     #region "RTF Stripping"
 


### PR DESCRIPTION
This pull request introduces a new PRs subsystem for triage and coaching, adds supporting commands, and refactors Kusto query handling to use a new `Table` abstraction for improved usability and consistency. It also includes enhancements to logging and new helper methods for Azure DevOps pull requests. The most important changes are grouped below:

### PRs Subsystem and Commands

* Added a new `PRsClient` class in `Subsytems/PRs/PRsClient.cs` that enables Kusto-backed pull request triage and coaching, including logic to build efficient KQL queries for PR slicing and fetching.
* Added a new set of PRs-related commands in `Subsytems/PRs/PRsCommands.cs`, providing CLI actions for fetching, reporting, slicing, and coaching on PRs using user-managed profiles.

### Kusto Query Refactoring

* Refactored Kusto query methods in `Subsytems/Kusto/KustoClient.cs` and all call sites to return a new `Table` object instead of separate columns/rows arrays, simplifying table handling and export operations. 
* 
* Updated all usages in Kusto commands and tools to leverage the new `Table` methods for rendering, exporting to CSV/JSON, and context management. 

### Azure DevOps Enhancements

* Added helper methods in `Subsytems/ADO/ADOClient.cs` for building pull request and discussion URLs, and fetching PR comment threads, supporting richer PR analysis and linking. 
