### PR TITLE
Feature/ux forms

### DIFF
--- a/Chat/ChatCommands.cs
+++ b/Chat/ChatCommands.cs
@@ -74,17 +74,21 @@ public partial class CommandManager
                 },
                 new Command
                 {
-                    Name = "default new chat name",
-                    Description = () => $"Set default name for new chat threads (current: {Program.config.ChatThreadSettings.DefaultNewThreadName})",
-                    Action = () =>
+                    Name = "new chat name",
+                    Description = () => $"Set default name for new chat threads [current: {Program.config.ChatThreadSettings.DefaultNewThreadName}]",
+                    Action = async () =>
                     {
-                        Program.ui.Write("New default name> ");
-                        var name = Program.ui.ReadLineWithHistory();
-                        if (string.IsNullOrWhiteSpace(name)) return Task.FromResult(Command.Result.Cancelled);
-                        Program.config.ChatThreadSettings.DefaultNewThreadName = name!;
-                        Config.Save(Program.config, Program.ConfigFilePath);
-                        Program.ui.WriteLine($"Default new chat thread name set to '{name}'.");
-                        return Task.FromResult(Command.Result.Success);
+                        var form = UiForm.Create("Set default new chat thread name", Program.config.ChatThreadSettings.DefaultNewThreadName);
+                        form.AddString("Default new thread name")
+                            .WithHelp("This is the name used for new chat threads.");
+
+                        if (await Program.ui.ShowFormAsync(form))
+                        {
+                            Program.config.ChatThreadSettings.DefaultNewThreadName = (string)form.Model!; // the CLONE with changes
+                            Config.Save(Program.config, Program.ConfigFilePath);
+                            return Command.Result.Success;
+                        }
+                        return Command.Result.Cancelled;
                     }
                 }
             }

--- a/Chat/ChatThread.cs
+++ b/Chat/ChatThread.cs
@@ -13,7 +13,7 @@ public sealed class ChatThread
 {
     [UserKey] public string Name { get; set; } = "";       // unique user-facing name
 
-    [UserField(required: false)]
+    [UserField(required: false, FieldKind = UiFieldKind.Text)]
     public string Description { get; set; } = ""; // optional description
 
     [UserField(required: false, hidden: true)]

--- a/Commands.cs
+++ b/Commands.cs
@@ -5,6 +5,8 @@ using System.Reflection;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 
+class ToolInputModel { public string Text { get; set; } = string.Empty; }
+
 public class Command
 {
     public enum Result
@@ -266,15 +268,13 @@ public partial class CommandManager : Command
                             var (guidance, isRequired) = GetInputFormatGuidance(toolInstance);
                             if (isRequired)
                             {
-                                Program.ui.WriteLine(guidance);
-                                Program.ui.WriteLine();
-                                Program.ui.Write("Enter input: ");
-
-                                // Get user input
-                                input = Program.ui.ReadLineWithHistory();
+                                var form = UiForm.Create($"Tool Input: {tool.Name}", new ToolInputModel { Text = string.Empty });
+                                form.AddString<ToolInputModel>("Input", m => m.Text, (m,v)=> m.Text = v)
+                                    .WithHelp(guidance);
+                                if (!await Program.ui.ShowFormAsync(form)) { return Command.Result.Cancelled; }
                                 try
                                 {
-                                    // Parse input based on the tool's expected input type
+                                    input = ((ToolInputModel)form.Model!).Text;
                                     toolInput = ParseToolInput(toolInstance, input ?? string.Empty);
                                 }
                                 catch (Exception ex)

--- a/Commands/RagConfigCommands.cs
+++ b/Commands/RagConfigCommands.cs
@@ -356,76 +356,75 @@ public partial class CommandManager
                 new Command
                 {
                     Name = "use embeddings", Description = () => $"Toggle the use of embeddings for RAG [currently: {(Program.config.RagSettings.UseEmbeddings ? "Enabled" : "Disabled")}]",
-                    Action = () =>
+                    Action = async () =>
                     {
-                        var selected = Program.ui.RenderMenu("Use embeddings:", new List<string> { "true", "false" }, Program.config.RagSettings.UseEmbeddings ? 0 : 1);
-                        if (selected == null)
+                        var form = UiForm.Create("Use Embeddings", Program.config.RagSettings.UseEmbeddings);
+                        form.AddBool("Enable")
+                            .WithHelp("Enable or disable the use of embeddings.");
+
+                        if (!await Program.ui.ShowFormAsync(form))
                         {
-                            Program.ui.WriteLine("No selection made.");
-                            return Task.FromResult(Command.Result.Cancelled);
+                            return Command.Result.Cancelled;
                         }
-                        if (!bool.TryParse(selected, out var useEmbeddings))
-                        {
-                            Program.ui.WriteLine("Invalid selection. Please select 'true' or 'false'.");
-                            return Task.FromResult(Command.Result.Failed);
-                        }
-                        Program.config.RagSettings.UseEmbeddings = useEmbeddings;
+                        Program.config.RagSettings.UseEmbeddings = (bool)form.Model!;
                         Config.Save(Program.config, Program.ConfigFilePath);
-                        Program.ui.WriteLine($"Use embeddings set to {Program.config.RagSettings.UseEmbeddings}");
-                        return Task.FromResult(Command.Result.Success);
+                        return Command.Result.Success;
                     }
                 },
                 new Command
                 {
                     Name = "embedding model", Description = () => $"Set the embedding model for RAG [currently: {Program.config.RagSettings.EmbeddingModel}]",
-                    Action = () =>
+                    Action = async () =>
                     {
-                        Program.ui.WriteLine($"Current embedding model: {Program.config.RagSettings.EmbeddingModel}");
-                        Program.ui.Write("Enter new embedding model (or press enter to keep current): ");
-                        var modelInput = Program.ui.ReadLineWithHistory();
-                        if (!string.IsNullOrWhiteSpace(modelInput))
+                        var form = UiForm.Create("Embedding Model", Program.config.RagSettings.EmbeddingModel);
+                        form.AddString("Model")
+                            .WithHelp("Enter the embedding model to use.");
+
+                        if (!await Program.ui.ShowFormAsync(form))
                         {
-                            Program.config.RagSettings.EmbeddingModel = modelInput.Trim();
-                            Config.Save(Program.config, Program.ConfigFilePath);
-                            Program.ui.WriteLine("Embedding model updated.");
+                            return Command.Result.Cancelled;
                         }
-                        return Task.FromResult(Command.Result.Success);
+                        Program.config.RagSettings.EmbeddingModel = (string)form.Model!;
+                        Config.Save(Program.config, Program.ConfigFilePath);
+                        return Command.Result.Success;
                     }
                 },
                 new Command
                 {
                     Name = "embedding concurrency", Description = () => $"Set the maximum concurrency for embedding generation [currently: {Program.config.RagSettings.MaxEmbeddingConcurrency}]",
-                    Action = () =>
+                    Action = async () =>
                     {
-                        var maxValue = 100;
-                        Program.ui.Write($"Current MaxEmbeddingConcurrency: {Program.config.RagSettings.MaxEmbeddingConcurrency}. Enter new value (1 to {maxValue}): ");
-                        var concurrencyInput = Program.ui.ReadLineWithHistory();
-                        if (int.TryParse(concurrencyInput, out var concurrency) && concurrency >= 1 && concurrency <= maxValue)
+                        var form = UiForm.Create("Embedding Concurrency", Program.config.RagSettings.MaxEmbeddingConcurrency);
+                        form.AddInt("Max Concurrency")
+                            .IntBounds(min: 1, max: 100)
+                            .WithHelp("Enter the maximum concurrency for embedding generation (1 to 100).");
+
+                        if (!await Program.ui.ShowFormAsync(form))
                         {
-                            Program.config.RagSettings.MaxEmbeddingConcurrency = concurrency;
-                            Config.Save(Program.config, Program.ConfigFilePath);
-                            Program.ui.WriteLine($"MaxEmbeddingConcurrency set to {concurrency}");
-                            return Task.FromResult(Command.Result.Success);
+                            return Command.Result.Cancelled;
                         }
-                        return Task.FromResult(Command.Result.Cancelled);
+                        Program.config.RagSettings.MaxEmbeddingConcurrency = (int)form.Model!;
+                        Config.Save(Program.config, Program.ConfigFilePath);
+                        return Command.Result.Success;
                     }
                 },
                 new Command
                 {
                     Name = "ingest concurrency", Description = () => $"Set the maximum concurrency for RAG ingestion [currently: {Program.config.RagSettings.MaxIngestConcurrency}]",
-                    Action = () =>
+                    Action = async () =>
                     {
-                        var maxValue = 100;
-                        Program.ui.Write($"Current MaxIngestConcurrency: {Program.config.RagSettings.MaxIngestConcurrency}. Enter new value (1 to {maxValue}): ");
-                        var concurrencyInput = Program.ui.ReadLineWithHistory();
-                        if (int.TryParse(concurrencyInput, out var concurrency) && concurrency >= 1 && concurrency <= maxValue)
+                        var form = UiForm.Create("Ingest Concurrency", Program.config.RagSettings.MaxIngestConcurrency);
+                        form.AddInt("Max Concurrency")       
+                            .IntBounds(min: 1, max: 100)
+                            .WithHelp("Enter the maximum concurrency for RAG ingestion (1 to 100).");
+
+                        if (!await Program.ui.ShowFormAsync(form))
                         {
-                            Program.config.RagSettings.MaxIngestConcurrency = concurrency;
-                            Config.Save(Program.config, Program.ConfigFilePath);
-                            Program.ui.WriteLine($"MaxIngestConcurrency set to {concurrency}");
-                            return Task.FromResult(Command.Result.Success);
+                            return Command.Result.Cancelled;
                         }
-                        return Task.FromResult(Command.Result.Cancelled);
+                        Program.config.RagSettings.MaxIngestConcurrency = (int)form.Model!;
+                        Config.Save(Program.config, Program.ConfigFilePath);
+                        return Command.Result.Success;
                     }
                 },
                 new Command
@@ -439,102 +438,105 @@ public partial class CommandManager
                         {
                             Program.config.RagSettings.ChunkingStrategy = selected;
                             Config.Save(Program.config, Program.ConfigFilePath);
-                            Program.ui.WriteLine($"Switched to chunker '{Program.config.RagSettings.ChunkingStrategy}'");
+                            return Task.FromResult(Command.Result.Success);
                         }
-                        return Task.FromResult(Command.Result.Success);
+                        return Task.FromResult(Command.Result.Cancelled);
                     }
                 },
                 new Command
                 {
                     Name = "chunk size", Description = () => $"Set the chunk size for RAG [currently: {Program.config.RagSettings.ChunkSize}]",
-                    Action = () =>
+                    Action = async () =>
                     {
-                        Program.ui.Write($"Current chunk size: {Program.config.RagSettings.ChunkSize}. Enter new value (1 to 10000): ");
-                        var sizeInput = Program.ui.ReadLineWithHistory();
-                        if (int.TryParse(sizeInput, out var size) && size >= 1 && size <= 10000)
+                        var form = UiForm.Create("Chunk Size", Program.config.RagSettings.ChunkSize);
+                        form.AddInt("Chunk Size")
+                            .IntBounds(min: 1, max: 10000)
+                            .WithHelp("Enter the chunk size (1 to 10000).");
+
+                        if (!await Program.ui.ShowFormAsync(form))
                         {
-                            Program.config.RagSettings.ChunkSize = size;
-                            Config.Save(Program.config, Program.ConfigFilePath);
-                            Program.ui.WriteLine($"Chunk size set to {size}");
+                            return Command.Result.Cancelled;
                         }
-                        else
-                        {
-                            Program.ui.WriteLine("Invalid chunk size value. Must be between 1 and 10000.");
-                        }
-                        return Task.FromResult(Command.Result.Success);
+                        Program.config.RagSettings.ChunkSize = (int)form.Model!;
+                        Config.Save(Program.config, Program.ConfigFilePath);
+                        return Command.Result.Success;
                     }
                 },
                 new Command
                 {
                     Name = "max tokens per chunk", Description = () => $"Set the maximum tokens per chunk for RAG [currently: {Program.config.RagSettings.MaxTokensPerChunk}]",
-                    Action = () =>
+                    Action = async () =>
                     {
-                        Program.ui.Write($"Current MaxTokensPerChunk: {Program.config.RagSettings.MaxTokensPerChunk}. Enter new value (1 to 32000): ");
-                        var maxTokensInput = Program.ui.ReadLineWithHistory();
-                        if (int.TryParse(maxTokensInput, out var maxTokens) && maxTokens >= 1 && maxTokens <= 32000)
+                        var form = UiForm.Create("Max Tokens Per Chunk", Program.config.RagSettings.MaxTokensPerChunk);
+                        form.AddInt("Max Tokens")
+                            .IntBounds(min: 1, max: 32000)
+                            .WithHelp("Enter the maximum tokens per chunk (1 to 32000).");
+
+                        if (!await Program.ui.ShowFormAsync(form))
                         {
-                            Program.config.RagSettings.MaxTokensPerChunk = maxTokens;
-                            Config.Save(Program.config, Program.ConfigFilePath);
-                            Program.ui.WriteLine($"MaxTokensPerChunk set to {maxTokens}");
+                            return Command.Result.Cancelled;
                         }
-                        return Task.FromResult(Command.Result.Success);
+                        Program.config.RagSettings.MaxTokensPerChunk = (int)form.Model!;
+                        Config.Save(Program.config, Program.ConfigFilePath);
+                        return Command.Result.Success;
                     }
                 },
                 new Command
                 {
                     Name = "max line length", Description = () => $"Set the maximum line length for RAG [currently: {Program.config.RagSettings.MaxLineLength}]",
-                    Action = () =>
+                    Action = async () =>
                     {
-                        Program.ui.Write($"Current MaxLineLength: {Program.config.RagSettings.MaxLineLength}. Enter new value (1 to 32000): ");
-                        var maxLineLengthInput = Program.ui.ReadLineWithHistory();
-                        if (int.TryParse(maxLineLengthInput, out var maxLineLength) && maxLineLength >= 1 && maxLineLength <= 32000)
+                        var form = UiForm.Create("Max Line Length", Program.config.RagSettings.MaxLineLength);
+                        form.AddInt("Max Line Length")
+                            .IntBounds(min: 1, max: 32000)
+                            .WithHelp("Enter the maximum line length (1 to 32000).");
+
+                        if (!await Program.ui.ShowFormAsync(form))
                         {
-                            Program.config.RagSettings.MaxLineLength = maxLineLength;
-                            Config.Save(Program.config, Program.ConfigFilePath);
-                            Program.ui.WriteLine($"MaxLineLength set to {maxLineLength}");
+                            return Command.Result.Cancelled;
                         }
-                        return Task.FromResult(Command.Result.Success);
+                        Program.config.RagSettings.MaxLineLength = (int)form.Model!;
+                        Config.Save(Program.config, Program.ConfigFilePath);
+                        return Command.Result.Success;
                     }
                 },
                 new Command
                 {
                     Name = "overlap", Description = () => $"Set the overlap size for RAG chunks [currently: {Program.config.RagSettings.Overlap}]",
-                    Action = () =>
+                    Action = async () =>
                     {
-                        Program.ui.Write($"Current overlap size: {Program.config.RagSettings.Overlap}. Enter new value (0 to 100): ");
-                        var overlapInput = Program.ui.ReadLineWithHistory();
-                        if (int.TryParse(overlapInput, out var overlap) && overlap >= 0 && overlap <= 100)
+                        var form = UiForm.Create("Overlap Size", Program.config.RagSettings.Overlap);
+                        form.AddInt("Overlap Size")
+                            .IntBounds(min: 0, max: 100)
+                            .WithHelp("Enter the overlap size (0 to 100).");
+                        
+                        if (!await Program.ui.ShowFormAsync(form))
                         {
-                            Program.config.RagSettings.Overlap = overlap;
-                            Config.Save(Program.config, Program.ConfigFilePath);
-                            Program.ui.WriteLine($"Overlap size set to {overlap}");
+                            return Command.Result.Cancelled;
                         }
-                        else
-                        {
-                            Program.ui.WriteLine("Invalid overlap size value. Must be between 0 and 100.");
-                        }
-                        return Task.FromResult(Command.Result.Success);
+                        Program.config.RagSettings.Overlap = (int)form.Model!;
+                        Config.Save(Program.config, Program.ConfigFilePath);
+                        return Command.Result.Success;
                     }
                 },
                 new Command
                 {
                     Name = "TopK", Description = () => $"Set the number of top results to return from RAG queries [currently: {Program.config.RagSettings.TopK}]",
-                    Action = () =>
+                    Action = async () =>
                     {
                         const int maxK = 25;
-                        Program.ui.Write($"Current TopK value: {Program.config.RagSettings.TopK}. Enter new value (1 to {maxK}): ");
-                        var topKInput = Program.ui.ReadLineWithHistory();
-                        if (int.TryParse(topKInput, out var topK) && topK >= 1 && topK <= maxK)
+                        var form = UiForm.Create("TopK", Program.config.RagSettings);
+                        form.AddInt<RagSettings>("TopK", v => v.TopK, (v, i) => v.TopK = i)
+                            .IntBounds(min: 1, max: maxK)
+                            .WithHelp($"Enter the number of top results to return (1 to {maxK}).");
+
+                        if (!await Program.ui.ShowFormAsync(form))
                         {
-                            Program.config.RagSettings.TopK = topK;
-                            Config.Save(Program.config, Program.ConfigFilePath);
-                            Program.ui.WriteLine($"TopK set to {topK}");
+                            return Command.Result.Cancelled;
                         }
-                        else
-                        {
-                            Program.ui.WriteLine("Invalid TopK value. Must be between 1 and {maxK}.");
-                        }
-                        return Task.FromResult(Command.Result.Success);
+                        Program.config.RagSettings.TopK = ((RagSettings)form.Model!).TopK;
+                        Config.Save(Program.config, Program.ConfigFilePath);
+                        return Command.Result.Success;
                     }
                 },
                 new Command
@@ -544,42 +546,45 @@ public partial class CommandManager
                     {
                         Program.config.RagSettings.UseMmr = !Program.config.RagSettings.UseMmr;
                         Config.Save(Program.config, Program.ConfigFilePath);
-                        Program.ui.WriteLine($"UseMmr set to {Program.config.RagSettings.UseMmr}");
                         return Task.FromResult(Command.Result.Success);
                     }
                 },
                 new Command
                 {
                     Name = "MMR Lambda", Description = () => $"Set the MMR lambda value for RAG [currently: {Program.config.RagSettings.MmrLambda}]",
-                    Action = () =>
+                    Action = async () =>
                     {
-                        Program.ui.Write($"Current MMR Lambda: {Program.config.RagSettings.MmrLambda}. Enter new value (0.0 to 1.0): ");
-                        var lambdaInput = Program.ui.ReadLineWithHistory();
-                        if (float.TryParse(lambdaInput, out var lambda) && lambda >= 0.0f && lambda <= 1.0f)
+                        var form = UiForm.Create("MMR Lambda", Program.config.RagSettings.MmrLambda);
+                        form.AddDouble("Lambda (0 to 1)")
+                            .IntBounds(min: 0, max: 1)
+                            .WithHelp("Enter the MMR lambda floating-point value (0 to 1).");
+
+                        if (!await Program.ui.ShowFormAsync(form))
                         {
-                            Program.config.RagSettings.MmrLambda = lambda;
-                            Config.Save(Program.config, Program.ConfigFilePath);
-                            Program.ui.WriteLine($"MMR Lambda set to {lambda}");
-                            return Task.FromResult(Command.Result.Success);
+                            return Command.Result.Cancelled;
                         }
-                        return Task.FromResult(Command.Result.Cancelled);
+                        Program.config.RagSettings.MmrLambda = (double)form.Model!;
+                        Config.Save(Program.config, Program.ConfigFilePath);
+                        return Command.Result.Success;
                     }
                 },
                 new Command
                 {
                     Name = "MMR Pool Multiplier" , Description = () => $"Set the MMR pool multiplier for RAG [currently: {Program.config.RagSettings.MmrPoolMultiplier}]",
-                    Action = () =>
+                    Action = async () =>
                     {
-                        Program.ui.Write($"Current MMR Pool Multiplier: {Program.config.RagSettings.MmrPoolMultiplier}. Enter new value (0.0 to 10.0): ");
-                        var multiplierInput = Program.ui.ReadLineWithHistory();
-                        if (float.TryParse(multiplierInput, out var multiplier) && multiplier >= 0.0f && multiplier <= 10.0f)
+                        var form = UiForm.Create("MMR Pool Multiplier", Program.config.RagSettings.MmrPoolMultiplier);
+                        form.AddFloat("Multiplier (0.0 to 10.0)")
+                            .IntBounds(min: 0, max: 10)
+                            .WithHelp("Enter the MMR pool multiplier (0.0 to 10.0).");
+                        
+                        if (!await Program.ui.ShowFormAsync(form))
                         {
-                            Program.config.RagSettings.MmrPoolMultiplier = multiplier;
-                            Config.Save(Program.config, Program.ConfigFilePath);
-                            Program.ui.WriteLine($"MMR Pool Multiplier set to {multiplier}");
-                            return Task.FromResult(Command.Result.Success);
+                            return Command.Result.Cancelled;
                         }
-                        return Task.FromResult(Command.Result.Cancelled);
+                        Program.config.RagSettings.MmrPoolMultiplier = (float)form.Model!;
+                        Config.Save(Program.config, Program.ConfigFilePath);
+                        return Command.Result.Success;
                     }
                 }
             }

--- a/Commands/RagConfigCommands.cs
+++ b/Commands/RagConfigCommands.cs
@@ -6,7 +6,6 @@ using System.Text.RegularExpressions;
 
 public partial class CommandManager
 {
-
     private static Command CreateRagConfigCommands()
     {
         return new Command

--- a/Commands/RagConfigCommands.cs
+++ b/Commands/RagConfigCommands.cs
@@ -6,344 +6,6 @@ using System.Text.RegularExpressions;
 
 public partial class CommandManager
 {
-    private static Command CreateRagFileTypeCommands()
-    {
-        return new Command
-        {
-            Name = "supported file types",
-            Description = () => "manage and configure RAG related settings for supported file types",
-            SubCommands = new List<Command>
-            {
-                new Command
-                {
-                    Name = "list", Description = () => "List all supported file types",
-                    Action = () =>
-                    {
-                        var fileTypes = Program.config.RagSettings.SupportedFileTypes;
-                        if (fileTypes.Count == 0)
-                        {
-                            Program.ui.WriteLine("No supported file types configured.");
-                        }
-                        else
-                        {
-                            Program.ui.WriteLine("Supported File Types:");
-                            foreach (var type in fileTypes)
-                            {
-                                Program.ui.WriteLine($"- {type}");
-                            }
-                        }
-                        return Task.FromResult(Command.Result.Success);
-                    }
-                },
-                new Command
-                {
-                    Name = "add", Description = () => "Add a new supported file type",
-                    Action = () =>
-                    {
-                        Program.ui.Write("Enter new file type (e.g., .txt, .md): ");
-                        var input = Program.ui.ReadLineWithHistory();
-                        if (!string.IsNullOrWhiteSpace(input) && !Program.config.RagSettings.SupportedFileTypes.Contains(input.Trim(), StringComparer.OrdinalIgnoreCase))
-                        {
-                            Program.config.RagSettings.SupportedFileTypes.Add(input.Trim());
-                            Config.Save(Program.config, Program.ConfigFilePath);
-                            Program.ui.WriteLine($"Added file type '{input.Trim()}' to supported types.");
-                        }
-                        else
-                        {
-                            Program.ui.WriteLine("Invalid or duplicate file type.");
-                        }
-                        return Task.FromResult(Command.Result.Success);
-                    }
-                },
-                new Command
-                {
-                    Name = "remove", Description = () => "Remove a supported file type",
-                    Action = () =>
-                    {
-                        Program.ui.Write("Enter file type to remove: ");
-                        var input = Program.ui.ReadLineWithHistory();
-                        if (!string.IsNullOrWhiteSpace(input) && Program.config.RagSettings.SupportedFileTypes.Remove(input.Trim()))
-                        {
-                            Config.Save(Program.config, Program.ConfigFilePath);
-                            Program.ui.WriteLine($"Removed file type '{input.Trim()}' from supported types.");
-                        }
-                        else
-                        {
-                            Program.ui.WriteLine("Invalid or non-existent file type.");
-                        }
-                        return Task.FromResult(Command.Result.Success);
-                    }
-                },
-                new Command
-                {
-                    Name = "clear", Description = () => "Clear all supported file types",
-                    Action = () =>
-                    {
-                        Program.config.RagSettings.SupportedFileTypes.Clear();
-                        Config.Save(Program.config, Program.ConfigFilePath);
-                        Program.ui.WriteLine("Cleared all supported file types.");
-                        return Task.FromResult(Command.Result.Success);
-                    }
-                },
-                new Command
-                {
-                    Name = "set", Description = () => "Set the supported file types from a comma-separated list",
-                    Action = () =>
-                    {
-                        Program.ui.Write("Enter comma-separated file types (e.g., .txt, .md): ");
-                        var input = Program.ui.ReadLineWithHistory();
-                        if (!string.IsNullOrWhiteSpace(input))
-                        {
-                            var types = input.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
-                                             .Select(t => t.Trim())
-                                             .Where(t => !string.IsNullOrWhiteSpace(t))
-                                             .ToHashSet(StringComparer.OrdinalIgnoreCase)
-                                             .ToList();
-                            Program.config.RagSettings.SupportedFileTypes = types;
-                            Config.Save(Program.config, Program.ConfigFilePath);
-                            Program.ui.WriteLine("Updated supported file types.");
-                        }
-                        return Task.FromResult(Command.Result.Success);
-                    }
-                },
-                new Command
-                {
-                    Name = "rules", Description = () => "Manage file filter rules for supported file types",
-                    SubCommands = new List<Command>
-                    {
-                        new Command
-                        {
-                            Name = "add exclude rule", Description = () => "Add an exclude rule for a file type",
-                            Action = () =>
-                            {
-                                // use menu to select file type to add exclude rule for
-                                var fileTypes = Program.config.RagSettings.SupportedFileTypes.ToList();
-                                if (fileTypes.Count == 0)
-                                {
-                                    Program.ui.WriteLine("No supported file types configured. Please add some first.");
-                                    return Task.FromResult(Command.Result.Failed);
-                                }
-                                var selectedType = Program.ui.RenderMenu("Select file type to add exclude rule for:", fileTypes);
-                                if (string.IsNullOrWhiteSpace(selectedType))
-                                {
-                                    Program.ui.WriteLine("No file type selected.");
-                                    return Task.FromResult(Command.Result.Cancelled);
-                                }
-                                var type = selectedType.Trim();
-                                if (!Program.config.RagSettings.FileFilters.TryGetValue(type, out var rules))
-                                {
-                                    rules = new FileFilterRules();
-                                    Program.config.RagSettings.FileFilters[type] = rules;
-                                }
-                                Program.ui.Write("Enter exclude regex pattern: ");
-                                var pattern = Program.ui.ReadLineWithHistory();
-                                if (!string.IsNullOrWhiteSpace(pattern))
-                                {
-                                    // validate that the pattern is a valid regex
-                                    try
-                                    {
-                                        new Regex(pattern);
-                                    }
-                                    catch (ArgumentException)
-                                    {
-                                        Program.ui.WriteLine("Invalid regex pattern.");
-                                        return Task.FromResult(Command.Result.Failed);
-                                    }
-                                    rules.Exclude.Add(pattern);
-                                    Config.Save(Program.config, Program.ConfigFilePath);
-                                    Program.ui.WriteLine($"Added exclude rule '{pattern}' for file type '{type}'.");
-                                }
-                                else
-                                {
-                                    Program.ui.WriteLine("Invalid pattern.");
-                                }
-                                return Task.FromResult(Command.Result.Success);
-                            }
-                        },
-                        new Command
-                        {
-                            Name = "add include rule", Description = () => "Add an include rule for a file type",
-                            Action = () =>
-                            {
-                                // use menu to select file type to add include rule for
-                                var fileTypes = Program.config.RagSettings.SupportedFileTypes.ToList();
-                                if (fileTypes.Count == 0)
-                                {
-                                    Program.ui.WriteLine("No supported file types configured. Please add some first.");
-                                    return Task.FromResult(Command.Result.Failed);
-                                }
-                                var selectedType = Program.ui.RenderMenu("Select file type to add include rule for:", fileTypes);
-                                if (string.IsNullOrWhiteSpace(selectedType))
-                                {
-                                    Program.ui.WriteLine("No file type selected.");
-                                    return Task.FromResult(Command.Result.Cancelled);
-                                }
-                                var type = selectedType.Trim();
-                                if (!Program.config.RagSettings.FileFilters.TryGetValue(type, out var rules))
-                                {
-                                    rules = new FileFilterRules();
-                                    Program.config.RagSettings.FileFilters[type] = rules;
-                                }
-                                Program.ui.Write("Enter include regex pattern: ");
-                                var pattern = Program.ui.ReadLineWithHistory();
-                                if (!string.IsNullOrWhiteSpace(pattern))
-                                {
-                                    // validate that the pattern is a valid regex
-                                    try
-                                    {
-                                        new Regex(pattern);
-                                    }
-                                    catch (ArgumentException)
-                                    {
-                                        Program.ui.WriteLine("Invalid regex pattern.");
-                                        return Task.FromResult(Command.Result.Failed);
-                                    }
-                                    rules.Include.Add(pattern);
-                                    Config.Save(Program.config, Program.ConfigFilePath);
-                                    Program.ui.WriteLine($"Added include rule '{pattern}' for file type '{type}'.");
-                                }
-                                else
-                                {
-                                    Program.ui.WriteLine("Invalid pattern.");
-                                }
-                                return Task.FromResult(Command.Result.Success);
-                            }
-                        },
-                        new Command
-                        {
-                            Name = "list rules", Description = () => "List all rules for a file type",
-                            Action = () =>
-                            {
-                                // use menu to select file type to list rules for
-                                var fileTypes = Program.config.RagSettings.SupportedFileTypes
-                                    .Where(ft=>
-                                        Program.config.RagSettings.FileFilters.ContainsKey(ft) &&
-                                        (Program.config.RagSettings.FileFilters[ft].Include.Count +
-                                         Program.config.RagSettings.FileFilters[ft].Exclude.Count) > 0)
-                                    .ToList();
-                                if (fileTypes.Count == 0)
-                                {
-                                    Program.ui.WriteLine("No rules configured for supported file types. Please add some first.");
-                                    return Task.FromResult(Command.Result.Failed);
-                                }
-                                var selectedType = Program.ui.RenderMenu("Select file type to list rules for:", fileTypes);
-                                if (string.IsNullOrWhiteSpace(selectedType))
-                                {
-                                    Program.ui.WriteLine("No file type selected.");
-                                    return Task.FromResult(Command.Result.Cancelled);
-                                }
-                                var type = selectedType.Trim();
-                                if (Program.config.RagSettings.FileFilters.TryGetValue(type, out var rules))
-                                {
-                                    Program.ui.WriteLine($"Rules for file type '{type}':");
-                                    Program.ui.WriteLine("Include Patterns:");
-                                    foreach (var include in rules.Include)
-                                    {
-                                        Program.ui.WriteLine($"- {include}");
-                                    }
-                                    Program.ui.WriteLine("Exclude Patterns:");
-                                    foreach (var exclude in rules.Exclude)
-                                    {
-                                        Program.ui.WriteLine($"- {exclude}");
-                                    }
-                                }
-                                else
-                                {
-                                    Program.ui.WriteLine($"No rules found for file type '{type}'.");
-                                }
-                                return Task.FromResult(Command.Result.Success);
-                            }
-                        },
-                        new Command
-                        {
-                            Name = "remove rule", Description = () => "Remove a rule from a file type",
-                            Action = () =>
-                            {
-                                // use menu to select file type to remove rule from
-                                var fileTypes = Program.config.RagSettings.SupportedFileTypes
-                                    .Where(ft=>
-                                        Program.config.RagSettings.FileFilters.ContainsKey(ft) &&
-                                        (Program.config.RagSettings.FileFilters[ft].Include.Count +
-                                         Program.config.RagSettings.FileFilters[ft].Exclude.Count) > 0)
-                                    .ToList();
-                                if (fileTypes.Count == 0)
-                                {
-                                    Program.ui.WriteLine("No supported file types configured. Please add some first.");
-                                    return Task.FromResult(Command.Result.Failed);
-                                }
-                                var selectedType = Program.ui.RenderMenu("Select file type to remove rule from:", fileTypes);
-                                if (string.IsNullOrWhiteSpace(selectedType))
-                                {
-                                    Program.ui.WriteLine("No file type selected.");
-                                    return Task.FromResult(Command.Result.Cancelled);
-                                }
-                                var type = selectedType.Trim();
-                                if (!Program.config.RagSettings.FileFilters.TryGetValue(type, out var rules))
-                                {
-                                    Program.ui.WriteLine($"No rules found for file type '{type}'.");
-                                    return Task.FromResult(Command.Result.Failed);
-                                }
-                                Program.ui.WriteLine("Select a rule to remove:");
-                                var choices = new List<string>();
-                                choices.AddRange(rules.Include.Where(p=>!string.IsNullOrWhiteSpace(p)).Select(p => $"Include: {p}"));
-                                choices.AddRange(rules.Exclude.Where(p=>!string.IsNullOrWhiteSpace(p)).Select(p => $"Exclude: {p}"));
-                                if (choices.Count == 0)
-                                {
-                                    Program.config.RagSettings.FileFilters.Remove(type);
-                                    Config.Save(Program.config, Program.ConfigFilePath);
-                                    Program.ui.WriteLine($"No rules found for file type '{type}'. Removed file type from configuration.");
-                                    return Task.FromResult(Command.Result.Success);
-                                }
-                                var selectedRule = Program.ui.RenderMenu("Select a rule to remove:", choices);
-                                if (string.IsNullOrWhiteSpace(selectedRule))
-                                {
-                                    Program.ui.WriteLine("No rule selected.");
-                                    return Task.FromResult(Command.Result.Cancelled);
-                                }
-                                choices.Remove(selectedRule);
-                                if (selectedRule.StartsWith("Include: "))
-                                {
-                                    var rule = selectedRule.Substring("Include: ".Length);
-                                    if (rules.Include.Remove(rule))
-                                    {
-                                        Program.ui.WriteLine($"Removed include rule '{rule}' from file type '{type}'.");
-                                    }
-                                    else
-                                    {
-                                        Program.ui.WriteLine($"Rule '{rule}' not found in include rules for file type '{type}'.");
-                                    }
-                                }
-                                else if (selectedRule.StartsWith("Exclude: "))
-                                {
-                                    var rule = selectedRule.Substring("Exclude: ".Length);
-                                    if (rules.Exclude.Remove(rule))
-                                    {
-                                        Program.ui.WriteLine($"Removed exclude rule '{rule}' from file type '{type}'.");
-                                    }
-                                    else
-                                    {
-                                        Program.ui.WriteLine($"Rule '{rule}' not found in exclude rules for file type '{type}'.");
-                                    }
-                                }
-                                else
-                                {
-                                    Program.ui.WriteLine("Invalid rule selected.");
-                                    return Task.FromResult(Command.Result.Failed);
-                                }
-                                if (0 == choices.Count)
-                                {
-                                    Program.config.RagSettings.FileFilters.Remove(type);
-                                    Program.ui.WriteLine($"No rules left for file type '{type}'. Removed file type from configuration.");
-                                }
-                                Config.Save(Program.config, Program.ConfigFilePath);
-                                return Task.FromResult(Command.Result.Success);
-                            }
-                        }
-                    }
-                }
-            }
-        };
-    }
 
     private static Command CreateRagConfigCommands()
     {
@@ -353,236 +15,93 @@ public partial class CommandManager
             Description = () => "RAG (Retrieval-Augmented Generation) configuration settings",
             SubCommands = new List<Command>
             {
+                // GROUP: Core Embedding Settings
                 new Command
                 {
-                    Name = "use embeddings", Description = () => $"Toggle the use of embeddings for RAG [currently: {(Program.config.RagSettings.UseEmbeddings ? "Enabled" : "Disabled")}]",
+                    Name = "Core Settings", Description = () => "Edit core embedding + retrieval settings (form)",
                     Action = async () =>
                     {
-                        var form = UiForm.Create("Use Embeddings", Program.config.RagSettings.UseEmbeddings);
-                        form.AddBool("Enable")
-                            .WithHelp("Enable or disable the use of embeddings.");
-
-                        if (!await Program.ui.ShowFormAsync(form))
-                        {
-                            return Command.Result.Cancelled;
-                        }
-                        Program.config.RagSettings.UseEmbeddings = (bool)form.Model!;
+                        var form = UiForm.Create("RAG – Core Settings", Program.config.RagSettings);
+                        form.AddBool<RagSettings>("Use Embeddings", m => m.UseEmbeddings, (m,v)=> m.UseEmbeddings = v, nameof(RagSettings.UseEmbeddings))
+                            .WithHelp("Enable/disable use of embeddings during retrieval.");
+                        form.AddString<RagSettings>("Embedding Model", m => m.EmbeddingModel, (m,v)=> m.EmbeddingModel = v, nameof(RagSettings.EmbeddingModel))
+                            .WithHelp("Embedding model identifier (provider specific).");
+                        form.AddInt<RagSettings>("TopK", m => m.TopK, (m,v)=> m.TopK = v, nameof(RagSettings.TopK))
+                            .IntBounds(1,25)
+                            .WithHelp("Number of similar chunks to retrieve.");
+                        form.AddInt<RagSettings>("TopK For Parsing", m => m.TopKForParsing, (m,v)=> m.TopKForParsing = v, nameof(RagSettings.TopKForParsing))
+                            .IntBounds(1,10)
+                            .WithHelp("Number of results to include for parsing context.");
+                        form.AddInt<RagSettings>("Embedding Concurrency", m => m.MaxEmbeddingConcurrency, (m,v)=> m.MaxEmbeddingConcurrency = v, nameof(RagSettings.MaxEmbeddingConcurrency))
+                            .IntBounds(1,100)
+                            .WithHelp("Max parallel embedding requests.");
+                        form.AddInt<RagSettings>("Ingest Concurrency", m => m.MaxIngestConcurrency, (m,v)=> m.MaxIngestConcurrency = v, nameof(RagSettings.MaxIngestConcurrency))
+                            .IntBounds(1,100)
+                            .WithHelp("Max parallel ingest tasks.");
+                        if (!await Program.ui.ShowFormAsync(form)) return Command.Result.Cancelled;
+                        Program.config.RagSettings = (RagSettings)form.Model!;
                         Config.Save(Program.config, Program.ConfigFilePath);
                         return Command.Result.Success;
                     }
                 },
+                // GROUP: Chunking Settings
                 new Command
                 {
-                    Name = "embedding model", Description = () => $"Set the embedding model for RAG [currently: {Program.config.RagSettings.EmbeddingModel}]",
-                    Action = async () =>
+                    Name = "Chunking", Description = () => "Edit chunking strategy + sizes (form)",
+                    Action = async () => await Log.MethodAsync(async ctx =>
                     {
-                        var form = UiForm.Create("Embedding Model", Program.config.RagSettings.EmbeddingModel);
-                        form.AddString("Model")
-                            .WithHelp("Enter the embedding model to use.");
-
+                        var form = UiForm.Create("RAG – Chunking", Program.config.RagSettings);
+                        // Provide a choice list for strategies
+                        var strategies = Program.Chunkers.Keys.OrderBy(k=>k).ToArray();
+                        ctx.Append(Log.Data.Choices, string.Join(", ", strategies));
+                        form.AddChoice<RagSettings>("Chunking Strategy", strategies, m=> m.ChunkingStrategy, (m,v)=> m.ChunkingStrategy = v, nameof(RagSettings.ChunkingStrategy))
+                            .WithHelp("Select which registered chunker to use.");
+                        form.AddInt<RagSettings>("Chunk Size", m=> m.ChunkSize, (m,v)=> m.ChunkSize = v, nameof(RagSettings.ChunkSize))
+                            .IntBounds(1,10000)
+                            .WithHelp("Target characters per chunk.");
+                        form.AddInt<RagSettings>("Max Tokens / Chunk", m=> m.MaxTokensPerChunk, (m,v)=> m.MaxTokensPerChunk = v, nameof(RagSettings.MaxTokensPerChunk))
+                            .IntBounds(1,32000)
+                            .WithHelp("Token count ceiling for a chunk.");
+                        form.AddInt<RagSettings>("Max Line Length", m=> m.MaxLineLength, (m,v)=> m.MaxLineLength = v, nameof(RagSettings.MaxLineLength))
+                            .IntBounds(1,32000)
+                            .WithHelp("Maximum characters permitted per line before wrapping.");
+                        form.AddInt<RagSettings>("Overlap", m=> m.Overlap, (m,v)=> m.Overlap = v, nameof(RagSettings.Overlap))
+                            .IntBounds(0,100)
+                            .WithHelp("Characters overlapping between consecutive chunks.");
                         if (!await Program.ui.ShowFormAsync(form))
                         {
+                            ctx.Append(Log.Data.Message, "User cancelled chunking config.");
+                            ctx.Succeeded();
                             return Command.Result.Cancelled;
                         }
-                        Program.config.RagSettings.EmbeddingModel = (string)form.Model!;
+                        Program.config.RagSettings = (RagSettings)form.Model!;
+                        ctx.Append(Log.Data.Result, $"Selected chunking strategy: {Program.config.RagSettings.ChunkingStrategy}");
+                        Engine.SetTextChunker(Program.config.RagSettings.ChunkingStrategy);
                         Config.Save(Program.config, Program.ConfigFilePath);
+                        ctx.Succeeded();
                         return Command.Result.Success;
-                    }
+                    })
                 },
+                // GROUP: MMR Settings
                 new Command
                 {
-                    Name = "embedding concurrency", Description = () => $"Set the maximum concurrency for embedding generation [currently: {Program.config.RagSettings.MaxEmbeddingConcurrency}]",
+                    Name = "MMR", Description = () => "Edit Maximal Marginal Relevance (form)",
                     Action = async () =>
                     {
-                        var form = UiForm.Create("Embedding Concurrency", Program.config.RagSettings.MaxEmbeddingConcurrency);
-                        form.AddInt("Max Concurrency")
-                            .IntBounds(min: 1, max: 100)
-                            .WithHelp("Enter the maximum concurrency for embedding generation (1 to 100).");
-
-                        if (!await Program.ui.ShowFormAsync(form))
-                        {
-                            return Command.Result.Cancelled;
-                        }
-                        Program.config.RagSettings.MaxEmbeddingConcurrency = (int)form.Model!;
-                        Config.Save(Program.config, Program.ConfigFilePath);
-                        return Command.Result.Success;
-                    }
-                },
-                new Command
-                {
-                    Name = "ingest concurrency", Description = () => $"Set the maximum concurrency for RAG ingestion [currently: {Program.config.RagSettings.MaxIngestConcurrency}]",
-                    Action = async () =>
-                    {
-                        var form = UiForm.Create("Ingest Concurrency", Program.config.RagSettings.MaxIngestConcurrency);
-                        form.AddInt("Max Concurrency")       
-                            .IntBounds(min: 1, max: 100)
-                            .WithHelp("Enter the maximum concurrency for RAG ingestion (1 to 100).");
-
-                        if (!await Program.ui.ShowFormAsync(form))
-                        {
-                            return Command.Result.Cancelled;
-                        }
-                        Program.config.RagSettings.MaxIngestConcurrency = (int)form.Model!;
-                        Config.Save(Program.config, Program.ConfigFilePath);
-                        return Command.Result.Success;
-                    }
-                },
-                new Command
-                {
-                    Name = "chunking method", Description = () => $"Select the text chunker for RAG [currently: {Program.config.RagSettings.ChunkingStrategy}]",
-                    Action = () =>
-                    {
-                        var chunkers = Program.Chunkers.Keys.ToList();
-                        var selected = Program.ui.RenderMenu("Select a text chunker:", chunkers, chunkers.IndexOf(Program.config.RagSettings.ChunkingStrategy));
-                        if (!string.IsNullOrWhiteSpace(selected) && !selected.Equals(Program.config.RagSettings.ChunkingStrategy, StringComparison.OrdinalIgnoreCase))
-                        {
-                            Program.config.RagSettings.ChunkingStrategy = selected;
-                            Config.Save(Program.config, Program.ConfigFilePath);
-                            return Task.FromResult(Command.Result.Success);
-                        }
-                        return Task.FromResult(Command.Result.Cancelled);
-                    }
-                },
-                new Command
-                {
-                    Name = "chunk size", Description = () => $"Set the chunk size for RAG [currently: {Program.config.RagSettings.ChunkSize}]",
-                    Action = async () =>
-                    {
-                        var form = UiForm.Create("Chunk Size", Program.config.RagSettings.ChunkSize);
-                        form.AddInt("Chunk Size")
-                            .IntBounds(min: 1, max: 10000)
-                            .WithHelp("Enter the chunk size (1 to 10000).");
-
-                        if (!await Program.ui.ShowFormAsync(form))
-                        {
-                            return Command.Result.Cancelled;
-                        }
-                        Program.config.RagSettings.ChunkSize = (int)form.Model!;
-                        Config.Save(Program.config, Program.ConfigFilePath);
-                        return Command.Result.Success;
-                    }
-                },
-                new Command
-                {
-                    Name = "max tokens per chunk", Description = () => $"Set the maximum tokens per chunk for RAG [currently: {Program.config.RagSettings.MaxTokensPerChunk}]",
-                    Action = async () =>
-                    {
-                        var form = UiForm.Create("Max Tokens Per Chunk", Program.config.RagSettings.MaxTokensPerChunk);
-                        form.AddInt("Max Tokens")
-                            .IntBounds(min: 1, max: 32000)
-                            .WithHelp("Enter the maximum tokens per chunk (1 to 32000).");
-
-                        if (!await Program.ui.ShowFormAsync(form))
-                        {
-                            return Command.Result.Cancelled;
-                        }
-                        Program.config.RagSettings.MaxTokensPerChunk = (int)form.Model!;
-                        Config.Save(Program.config, Program.ConfigFilePath);
-                        return Command.Result.Success;
-                    }
-                },
-                new Command
-                {
-                    Name = "max line length", Description = () => $"Set the maximum line length for RAG [currently: {Program.config.RagSettings.MaxLineLength}]",
-                    Action = async () =>
-                    {
-                        var form = UiForm.Create("Max Line Length", Program.config.RagSettings.MaxLineLength);
-                        form.AddInt("Max Line Length")
-                            .IntBounds(min: 1, max: 32000)
-                            .WithHelp("Enter the maximum line length (1 to 32000).");
-
-                        if (!await Program.ui.ShowFormAsync(form))
-                        {
-                            return Command.Result.Cancelled;
-                        }
-                        Program.config.RagSettings.MaxLineLength = (int)form.Model!;
-                        Config.Save(Program.config, Program.ConfigFilePath);
-                        return Command.Result.Success;
-                    }
-                },
-                new Command
-                {
-                    Name = "overlap", Description = () => $"Set the overlap size for RAG chunks [currently: {Program.config.RagSettings.Overlap}]",
-                    Action = async () =>
-                    {
-                        var form = UiForm.Create("Overlap Size", Program.config.RagSettings.Overlap);
-                        form.AddInt("Overlap Size")
-                            .IntBounds(min: 0, max: 100)
-                            .WithHelp("Enter the overlap size (0 to 100).");
-                        
-                        if (!await Program.ui.ShowFormAsync(form))
-                        {
-                            return Command.Result.Cancelled;
-                        }
-                        Program.config.RagSettings.Overlap = (int)form.Model!;
-                        Config.Save(Program.config, Program.ConfigFilePath);
-                        return Command.Result.Success;
-                    }
-                },
-                new Command
-                {
-                    Name = "TopK", Description = () => $"Set the number of top results to return from RAG queries [currently: {Program.config.RagSettings.TopK}]",
-                    Action = async () =>
-                    {
-                        const int maxK = 25;
-                        var form = UiForm.Create("TopK", Program.config.RagSettings);
-                        form.AddInt<RagSettings>("TopK", v => v.TopK, (v, i) => v.TopK = i)
-                            .IntBounds(min: 1, max: maxK)
-                            .WithHelp($"Enter the number of top results to return (1 to {maxK}).");
-
-                        if (!await Program.ui.ShowFormAsync(form))
-                        {
-                            return Command.Result.Cancelled;
-                        }
-                        Program.config.RagSettings.TopK = ((RagSettings)form.Model!).TopK;
-                        Config.Save(Program.config, Program.ConfigFilePath);
-                        return Command.Result.Success;
-                    }
-                },
-                new Command
-                {
-                    Name = "Use MMR", Description = () => $"Toggle the use of MMR for RAG [currently: {Program.config.RagSettings.UseMmr}]",
-                    Action = () =>
-                    {
-                        Program.config.RagSettings.UseMmr = !Program.config.RagSettings.UseMmr;
-                        Config.Save(Program.config, Program.ConfigFilePath);
-                        return Task.FromResult(Command.Result.Success);
-                    }
-                },
-                new Command
-                {
-                    Name = "MMR Lambda", Description = () => $"Set the MMR lambda value for RAG [currently: {Program.config.RagSettings.MmrLambda}]",
-                    Action = async () =>
-                    {
-                        var form = UiForm.Create("MMR Lambda", Program.config.RagSettings.MmrLambda);
-                        form.AddDouble("Lambda (0 to 1)")
-                            .IntBounds(min: 0, max: 1)
-                            .WithHelp("Enter the MMR lambda floating-point value (0 to 1).");
-
-                        if (!await Program.ui.ShowFormAsync(form))
-                        {
-                            return Command.Result.Cancelled;
-                        }
-                        Program.config.RagSettings.MmrLambda = (double)form.Model!;
-                        Config.Save(Program.config, Program.ConfigFilePath);
-                        return Command.Result.Success;
-                    }
-                },
-                new Command
-                {
-                    Name = "MMR Pool Multiplier" , Description = () => $"Set the MMR pool multiplier for RAG [currently: {Program.config.RagSettings.MmrPoolMultiplier}]",
-                    Action = async () =>
-                    {
-                        var form = UiForm.Create("MMR Pool Multiplier", Program.config.RagSettings.MmrPoolMultiplier);
-                        form.AddFloat("Multiplier (0.0 to 10.0)")
-                            .IntBounds(min: 0, max: 10)
-                            .WithHelp("Enter the MMR pool multiplier (0.0 to 10.0).");
-                        
-                        if (!await Program.ui.ShowFormAsync(form))
-                        {
-                            return Command.Result.Cancelled;
-                        }
-                        Program.config.RagSettings.MmrPoolMultiplier = (float)form.Model!;
+                        var form = UiForm.Create("RAG – MMR", Program.config.RagSettings);
+                        form.AddBool<RagSettings>("Use MMR", m=> m.UseMmr, (m,v)=> m.UseMmr = v, nameof(RagSettings.UseMmr))
+                            .WithHelp("Toggle diversity-based re-ranking.");
+                        form.AddDouble<RagSettings>("Lambda (0-1)", m=> m.MmrLambda, (m,v)=> m.MmrLambda = v, nameof(RagSettings.MmrLambda))
+                            .IntBounds(0,1)
+                            .WithHelp("Balance relevance (near 1) vs diversity (near 0).");
+                        form.AddFloat<RagSettings>("Pool Multiplier", m=> m.MmrPoolMultiplier, (m,v)=> m.MmrPoolMultiplier = v, nameof(RagSettings.MmrPoolMultiplier))
+                            .IntBounds(0,10)
+                            .WithHelp("Candidate pool = TopK * multiplier.");
+                        form.AddInt<RagSettings>("Min Extra Candidates", m=> m.MmrMinExtra, (m,v)=> m.MmrMinExtra = v, nameof(RagSettings.MmrMinExtra))
+                            .IntBounds(0,100)
+                            .WithHelp("Minimum extra candidates beyond TopK.");
+                        if (!await Program.ui.ShowFormAsync(form)) return Command.Result.Cancelled;
+                        Program.config.RagSettings = (RagSettings)form.Model!;
                         Config.Save(Program.config, Program.ConfigFilePath);
                         return Command.Result.Success;
                     }

--- a/Commands/SubsystemCommands.cs
+++ b/Commands/SubsystemCommands.cs
@@ -9,60 +9,34 @@ public partial class CommandManager
     {
         return new Command
         {
-            Name = "subsystem", Description = () => "Subsystem management commands",
-            SubCommands = new List<Command>
+            Name = "Subsystem", Description = () => "Enable/disable subsystem state",    
+            Action = () =>
             {
-                new Command
+                // use menu to select subsystem
+                var subsystems = Program.SubsystemManager.Names.ToList();
+                if (!subsystems.Any())
                 {
-                    Name = "list", Description = () => "List all available subsystems",
-                    Action = () =>
-                    {
-                        var subsystems = Program.SubsystemManager.Names.ToList();
-                        if (!subsystems.Any())
-                        {
-                            Program.ui.WriteLine("No subsystems available.");
-                            return Task.FromResult(Command.Result.Success);
-                        }
-                        Program.ui.WriteLine("Available subsystems:");
-                        foreach (var subsystem in subsystems)
-                        {
-                            Program.ui.WriteLine($"- {subsystem} : Type:{Program.SubsystemManager.GetType(subsystem).ToString()} [{(Program.SubsystemManager.IsEnabled(subsystem) ? "enabled" : "disabled")}]");
-                        }
-                        return Task.FromResult(Command.Result.Success);
-                    }
-                },
-                new Command
-                {
-                    Name = "enable/disable", Description = () => "Toggle a subsystem's enabled/disabled state",
-                    Action = () =>
-                    {
-                        // use menu to select subsystem
-                        var subsystems = Program.SubsystemManager.Names.ToList();
-                        if (!subsystems.Any())
-                        {
-                            Program.ui.WriteLine("No subsystems available to toggle.");
-                            return Task.FromResult(Command.Result.Success);
-                        }
-                        Program.ui.WriteLine("Select a subsystem to toggle:");
-
-                        var selected = Program.ui.RenderMenu("select subsystem to toggle",subsystems.Select(s => $"{s} : [{(Program.SubsystemManager.IsEnabled(s)?"enabled":"disabled")}]").ToList());
-                        if (string.IsNullOrWhiteSpace(selected))
-                        {
-                            Program.ui.WriteLine("No subsystem selected.");
-                            return Task.FromResult(Command.Result.Cancelled);
-                        }
-                        var name = selected.Split(':').FirstOrDefault()?.Trim();
-                        if (string.IsNullOrWhiteSpace(name))
-                        {
-                            Program.ui.WriteLine("Invalid subsystem name.");
-                            return Task.FromResult(Command.Result.Cancelled);
-                        }
-                        Program.SubsystemManager.SetEnabled(name, !Program.SubsystemManager.IsEnabled(name));
-                        Config.Save(Program.config, Program.ConfigFilePath);
-                        Program.ui.WriteLine($"Subsystem '{name}' is now {(Program.SubsystemManager.IsEnabled(name) ? "enabled" : "disabled")}.");
-                        return Task.FromResult(Command.Result.Success);
-                    }
+                    Program.ui.WriteLine("No subsystems available to toggle.");
+                    return Task.FromResult(Command.Result.Success);
                 }
+                Program.ui.WriteLine("Select a subsystem to toggle:");
+
+                var selected = Program.ui.RenderMenu("select subsystem to toggle",subsystems.Select(s => $"{s} : [{(Program.SubsystemManager.IsEnabled(s)?"enabled":"disabled")}]").ToList());
+                if (string.IsNullOrWhiteSpace(selected))
+                {
+                    Program.ui.WriteLine("No subsystem selected.");
+                    return Task.FromResult(Command.Result.Cancelled);
+                }
+                var name = selected.Split(':').FirstOrDefault()?.Trim();
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    Program.ui.WriteLine("Invalid subsystem name.");
+                    return Task.FromResult(Command.Result.Cancelled);
+                }
+                Program.SubsystemManager.SetEnabled(name, !Program.SubsystemManager.IsEnabled(name));
+                Config.Save(Program.config, Program.ConfigFilePath);
+                Program.ui.WriteLine($"Subsystem '{name}' is now {(Program.SubsystemManager.IsEnabled(name) ? "enabled" : "disabled")}.");
+                return Task.FromResult(Command.Result.Success);
             }
         };
     }

--- a/Commands/SystemCommands.cs
+++ b/Commands/SystemCommands.cs
@@ -180,41 +180,37 @@ public partial class CommandManager
                     new Command
                     {
                         Name = "max menu items", Description = () => $"Configure maximum number of menu items displayed at once [currently: {Program.config.MaxMenuItems}]",
-                        Action = () =>
+                        Action = async () =>
                         {
-                            Program.ui.WriteLine($"Current max menu items: {Program.config.MaxMenuItems}");
-                            Program.ui.Write("Enter new value (minimum 1): ");
-                            var input = Program.ui.ReadLineWithHistory();
-                            if (int.TryParse(input, out int value) && value >= 1)
+                            var form = UiForm.Create("Configure menu items", Program.config);
+                form.AddInt<Config>("Max menu items", c => c.MaxMenuItems, (c,v) => c.MaxMenuItems = v)
+                                    .IntBounds(min: 1, max: 200)
+                                    .WithHelp("Controls how many choices are rendered at once, range is 1 to 200.");
+                            if (await Program.ui.ShowFormAsync(form))
                             {
-                                Program.config.MaxMenuItems = value;
+                                Program.config = (Config)form.Model!;        // commit the edited clone
                                 Config.Save(Program.config, Program.ConfigFilePath);
-                                Program.ui.WriteLine($"Max menu items set to {value}");
+                                return Command.Result.Success;
                             }
-                            else
-                            {
-                                Program.ui.WriteLine("Invalid input. Please enter a number >= 1.");
-                            }
-                            return Task.FromResult(Command.Result.Success);
+                            return Command.Result.Cancelled;
                         }
                     },
                     new Command
                     {
                         Name = "set max steps", Description = () => $"Set maximum steps for planning [currently: {Program.config.MaxSteps}]",
-                        Action = () =>
+                        Action = async () =>
                         {
-                            Program.ui.Write("Enter maximum steps (default 25): ");
-                            var input = Program.ui.ReadLine();
-                            if (int.TryParse(input, out int maxSteps))
+                            var form = UiForm.Create("Configure maximum steps", Program.config);
+                form.AddInt<Config>("Max steps", c => c.MaxSteps, (c,v) => c.MaxSteps = v)
+                                    .IntBounds(min: 1, max: 100)
+                                    .WithHelp("Controls how many steps the planner can take, range is 1 to 100.");
+                            if (await Program.ui.ShowFormAsync(form))
                             {
-                                Program.config.MaxSteps = maxSteps;
-                                Program.ui.WriteLine($"Maximum steps set to {maxSteps}.");
+                                Program.config = (Config)form.Model!;        // commit the edited clone
+                                Config.Save(Program.config, Program.ConfigFilePath);
+                                return Command.Result.Success;
                             }
-                            else
-                            {
-                                Program.ui.WriteLine($"Invalid input. Maximum steps remain at {Program.config.MaxSteps}.");
-                            }
-                            return Task.FromResult(Command.Result.Success);
+                            return Command.Result.Cancelled;
                         }
                     }                    
                 }

--- a/Commands/SystemCommands.cs
+++ b/Commands/SystemCommands.cs
@@ -220,7 +220,6 @@ public partial class CommandManager
         // Add provider/rag/tool/subsystem commands
         subCommands.Add(CreateProviderCommands());
         subCommands.Add(CreateRagConfigCommands());
-        subCommands.Add(CreateRagFileTypeCommands());
         subCommands.Add(CreateADOConfigCommands());
         subCommands.Add(CreateSubsystemCommands());
 

--- a/Config.cs
+++ b/Config.cs
@@ -40,7 +40,8 @@ public class RagSettings
     public int MmrMinExtra { get; set; } = 4;       // at least +4 candidates
     public int TopKForParsing { get; set; } = 2; // how many top results to use for parsing
 
-    public List<string> SupportedFileTypes { get; set; } = new List<string>
+    [Obsolete("Use UserManagedData RagFileType entries instead. This legacy list is only used during migration if no RagFileType entries exist.")]
+    public List<string> SupportedFileTypes { get; set; } = new List<string> // TODO: remove in subsequent change as part of wrapping up migration to RagFileType.
     {
         ".bash", ".bat",
         ".c", ".cpp", ".cs", ".csproj", ".csv",
@@ -55,6 +56,7 @@ public class RagSettings
         ".xml",
         ".yml"
     };
+    [Obsolete("Use Include/Exclude lists on RagFileType (UserManagedData) instead.")]
     public Dictionary<string, FileFilterRules> FileFilters { get; set; } = new();
 }
 
@@ -82,7 +84,7 @@ public class Config
 
     public string DefaultDirectory { get; set; } = Directory.GetCurrentDirectory();
 
-    public RagSettings RagSettings { get; set; } = new RagSettings();
+    public RagSettings RagSettings { get; set; } = new RagSettings(); 
 
     public bool VerboseEventLoggingEnabled { get; set; } = false;
     public int MaxSteps { get; set; } = 25; // Maximum number of steps for planning

--- a/Context.cs
+++ b/Context.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text.Json;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Collections.Generic;

--- a/Graph.cs
+++ b/Graph.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text.Json;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Collections.Generic;

--- a/Log.cs
+++ b/Log.cs
@@ -70,9 +70,10 @@ public static class Log
             return this;
         }
 
-        public void OnlyEmitOnFailure()
+        public Context OnlyEmitOnFailure()
         {
             _items[Data.Level] = Level.Verbose;
+            return this;
         }
 
         public void Succeeded(bool success = true)

--- a/Log.cs
+++ b/Log.cs
@@ -43,7 +43,7 @@ public static class Log
         Provider, Model, Version, GitHash, ProviderSet, Result, FilePath, Query, Name, Scores, Registered, Reason,
         ToolName, ToolInput, ParsedInput, Enabled, Error, Reference, Goal, Step, Input, TypeToParse, PlanningFailed,
         Command, ServerName, Names, Schema, ExampleText, MenuTop, ConsoleHeight, ConsoleWidth, InputTop, Host, Output,
-        Id, Kql,
+        Id, Kql, Type,
     }
 
     public enum Level { Verbose, Information, Warning, Error }

--- a/Log.cs
+++ b/Log.cs
@@ -43,7 +43,7 @@ public static class Log
         Provider, Model, Version, GitHash, ProviderSet, Result, FilePath, Query, Name, Scores, Registered, Reason,
         ToolName, ToolInput, ParsedInput, Enabled, Error, Reference, Goal, Step, Input, TypeToParse, PlanningFailed,
         Command, ServerName, Names, Schema, ExampleText, MenuTop, ConsoleHeight, ConsoleWidth, InputTop, Host, Output,
-        Id, Kql, Type, Key,
+        Id, Kql, Type, Key, Choices,
     }
 
     public enum Level { Verbose, Information, Warning, Error }

--- a/Log.cs
+++ b/Log.cs
@@ -43,7 +43,7 @@ public static class Log
         Provider, Model, Version, GitHash, ProviderSet, Result, FilePath, Query, Name, Scores, Registered, Reason,
         ToolName, ToolInput, ParsedInput, Enabled, Error, Reference, Goal, Step, Input, TypeToParse, PlanningFailed,
         Command, ServerName, Names, Schema, ExampleText, MenuTop, ConsoleHeight, ConsoleWidth, InputTop, Host, Output,
-        Id, Kql, Type,
+        Id, Kql, Type, Key,
     }
 
     public enum Level { Verbose, Information, Warning, Error }

--- a/README.md
+++ b/README.md
@@ -250,6 +250,39 @@ Key points:
 
 This component is intended for small, developer-maintained collections and not for large data stores or sensitive secrets.
 
+### `UserFieldAttribute` options (UI hints)
+
+`UserFieldAttribute` now supports several optional properties to control how fields are presented in forms:
+
+- `FieldKind` (UiFieldKind): hint for the renderer whether to use a single-line input (`String`), multi-line text area (`Text`), password input (`Password`), path picker (`Path`), or show a dropdown for choices (`Enum`). Defaults to `Text` (preserves legacy behavior).
+- `Placeholder` (string): placeholder text shown in the input when empty.
+- `Min`, `Max` (int?): integer bounds applied to integer/long fields.
+- `Pattern` (string): regex pattern used for client-side validation (UI may show the `PatternMessage` when invalid).
+- `Choices` (string[]): fixed list of allowed string values; when present on a string property the UI renders a dropdown/select.
+
+Examples:
+
+```csharp
+[UserField(required: true, display: "Cluster URI", FieldKind = UiFieldKind.String, Placeholder = "https://example.kusto.windows.net")]
+public string ClusterUri { get; set; } = "";
+
+[UserField(display: "Description", FieldKind = UiFieldKind.Text)]
+public string Description { get; set; } = ""; // multi-line
+
+[UserField(required: true, FieldKind = UiFieldKind.Path)]
+public string Path { get; set; } = ""; // UI may provide path autocomplete
+
+[UserField(display: "Mode", Choices = new[]{ "auto", "manual", "off" })]
+public string Mode { get; set; } = "auto"; // renders as dropdown/select
+
+[UserField(required: true, display: "Retries", Min = 0, Max = 10)]
+public int Retries { get; set; } = 3;
+```
+
+Notes:
+- Enum-typed properties continue to render as dropdowns automatically (no need to set `Choices`).
+- The terminal UI renders dropdowns using the menu system; graphical UIs (Photino) will render a native select control when available.
+
 ## How it works
 - On startup, loads or creates a configuration file (`config.json`) for provider, host, model, and system prompt.
 - Initializes providers, command system, and in-memory chat history.

--- a/RagFileType.cs
+++ b/RagFileType.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+
+// Represents a supported file type for RAG ingestion and its filtering rules.
+// This replaces (over time) RagSettings.SupportedFileTypes and RagSettings.FileFilters.
+// Migration logic in Program.InitProgramAsync will populate initial entries from legacy config.
+[UserManagedAttribute("RAG File Type", "Supported file type for RAG ingestion and filtering rules.")]
+public class RagFileType
+{
+    [UserKey]
+    [UserField(required: true, display: "Extension", hint: "File extension including leading dot (e.g. .cs, .md)", FieldKind = UiFieldKind.String)]
+    public string Extension { get; set; } = string.Empty;
+
+    [UserField(display: "Enabled", hint: "If unchecked, this file type will be ignored during ingestion.", FieldKind = UiFieldKind.Bool)]
+    public bool Enabled { get; set; } = true;
+
+    [UserField(display: "Include Patterns", hint: "Regex patterns; a file must match at least one include (if any present).", FieldKind = UiFieldKind.String)]
+    public List<string> Include { get; set; } = new();
+
+    [UserField(display: "Exclude Patterns", hint: "Regex patterns; if any match the file will be skipped.", FieldKind = UiFieldKind.String)]
+    public List<string> Exclude { get; set; } = new();
+
+    [UserField(display: "Description", hint: "Optional description for this file type.", FieldKind = UiFieldKind.Text)]
+    public string? Description { get; set; }
+
+    public override string ToString() => $"{Extension} {(Enabled?"✅":"❌")}{(Include.Count>0?" Include=["+string.Join(", ", Include)+"]":"")}{(Exclude.Count>0?" Exclude=["+string.Join(", ", Exclude)+"]":"")}";
+}

--- a/Subsytems/ADO/ADOConfigCommands.cs
+++ b/Subsytems/ADO/ADOConfigCommands.cs
@@ -1,9 +1,7 @@
 using System;
-using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 public partial class CommandManager : Command
 {
@@ -11,303 +9,133 @@ public partial class CommandManager : Command
     {
         return new Command
         {
-            Name = "Azure Dev Ops (ADO)", Description = () => "configuration settings",
+            Name = "Azure Dev Ops (ADO)",
+            Description = () => "configuration settings",
             SubCommands = new List<Command>
             {
                 new Command
                 {
-                    Name = "organization", Description = () => $"Set Azure DevOps organization [currently: {Program.config.Ado.Organization}]",
-                    Action = () =>
+                    Name = "Config",
+                    Description = () => "Edit organization, project, repository, and authentication",
+                    Action = async () =>
                     {
-                        Program.ui.Write("Enter new Azure DevOps organization: ");
-                        var org = Program.ui.ReadLine();
-                        if (!string.IsNullOrWhiteSpace(org))
-                        {
-                            Program.config.Ado.Organization = org;
-                            Config.Save(Program.config, Program.ConfigFilePath);
-                            Program.ui.WriteLine($"Azure DevOps organization set to: {org}");
-                            return Task.FromResult(Command.Result.Success);
-                        }
-                        return Task.FromResult(Command.Result.Cancelled);
-                    }
+                        // Build a typed form on a cloned ADO config object
+                        var form = UiForm.Create("Azure DevOps Config", Program.config.Ado);
 
-                },
-                new Command
-                {
-                    Name = "project", Description = () => $"Set Azure DevOps project [currently: {Program.config.Ado.ProjectName}]",
-                    Action = () =>
-                    {
-                        Program.ui.Write("Enter new Azure DevOps project: ");
-                        var project = Program.ui.ReadLine();
-                        if (!string.IsNullOrWhiteSpace(project))
-                        {
-                            Program.config.Ado.ProjectName = project;
-                            Config.Save(Program.config, Program.ConfigFilePath);
-                            Program.ui.WriteLine($"Azure DevOps project set to: {project}");
-                            return Task.FromResult(Command.Result.Success);
-                        }
-                        return Task.FromResult(Command.Result.Cancelled);
-                    }
-                },
-                new Command
-                {
-                    Name = "repository", Description = () => $"Set Azure DevOps repository [currently: {Program.config.Ado.RepositoryName}]",
-                    Action = () =>
-                    {
-                        Program.ui.Write("Enter new Azure DevOps repository: ");
-                        var repo = Program.ui.ReadLine();
-                        if (!string.IsNullOrWhiteSpace(repo))
-                        {
-                            Program.config.Ado.RepositoryName = repo;
-                            Config.Save(Program.config, Program.ConfigFilePath);
-                            Program.ui.WriteLine($"Azure DevOps repository set to: {repo}");
-                            return Task.FromResult(Command.Result.Success);
-                        }
-                        return Task.FromResult(Command.Result.Cancelled);
-                    }
-                },
-                new Command
-                {
-                    Name ="Use OAuth Scope", Description = () => $"Toggle using Azure DevOps OAuth scope for authentication [currently: {Program.config.Ado.UseOAuthScope}]",
-                    Action = () =>
-                    {
-                        Program.config.Ado.UseOAuthScope = !Program.config.Ado.UseOAuthScope;
+                        form.AddString<dynamic>("Organization",
+                            m => (string)(m.Organization ?? ""),
+                            (m, v) => m.Organization = v, "Organization")
+                            .WithHelp("Your ADO org name (e.g., 'myorg').")
+                            .MakeOptional();
+
+                        form.AddString<dynamic>("Project",
+                            m => (string)(m.ProjectName ?? ""),
+                            (m, v) => m.ProjectName = v, "ProjectName")
+                            .WithHelp("Default ADO project.")
+                            .MakeOptional();
+
+                        form.AddString<dynamic>("Repository",
+                            m => (string)(m.RepositoryName ?? ""),
+                            (m, v) => m.RepositoryName = v, "RepositoryName")
+                            .WithHelp("Default ADO repo.")
+                            .MakeOptional();
+
+                        form.AddBool<dynamic>("Use OAuth Scope",
+                            m => (bool)(m.UseOAuthScope ?? false),
+                            (m, v) => m.UseOAuthScope = v, "UseOAuthScope")
+                            .WithHelp("Toggle using the ADO OAuth scope for authentication.");
+
+                        // AdoOauthScope is stored as string; validate as GUID text with a regex.
+                        form.AddString<dynamic>("OAuth Scope (GUID)",
+                            m => (string)(m.AdoOauthScope ?? ""),
+                            (m, v) => m.AdoOauthScope = (v ?? "").Trim(), "AdoOauthScope")
+                            .WithRegex(@"^\s*$|^[A-Fa-f0-9]{8}\-[A-Fa-f0-9]{4}\-[A-Fa-f0-9]{4}\-[A-Fa-f0-9]{4}\-[A-Fa-f0-9]{12}\s*$",
+                                       "Must be blank or a GUID like 00000000-0000-0000-0000-000000000000.")
+                            .WithHelp("Leave blank to unset.");
+
+                        if (!await Program.ui.ShowFormAsync(form))
+                            return Command.Result.Cancelled;
+
+                        // Copy edited clone back into the live config object
+                        Program.config.Ado = (AdoConfig)form.Model!;
+
                         Config.Save(Program.config, Program.ConfigFilePath);
-                        Program.ui.WriteLine($"Use Azure DevOps OAuth scope for authentication set to: {Program.config.Ado.UseOAuthScope}");
-                        return Task.FromResult(Command.Result.Success);
+                        Program.ui.WriteLine("ADO basics saved.");
+                        return Command.Result.Success;
                     }
                 },
                 new Command
                 {
-                    Name = "AdoOAuthScope", Description = () => $"Set Azure DevOps OAuth scope [currently: {Program.config.Ado.AdoOauthScope}]",
-                    Action = () =>
+                    Name = "Insights",
+                    Description = () => "Edit Insights scoring + critical tags (form)",
+                    Action = async () =>
                     {
-                        Program.ui.Write("Enter new Azure DevOps OAuth scope (GUID): ");
-                        var scope = Program.ui.ReadLine();
-                        if (!string.IsNullOrWhiteSpace(scope) && Guid.TryParse(scope, out var guid))
-                        {
-                            Program.config.Ado.AdoOauthScope = guid.ToString();
-                            Config.Save(Program.config, Program.ConfigFilePath);
-                            Program.ui.WriteLine($"Azure DevOps OAuth scope set to: {guid}");
-                            return Task.FromResult(Command.Result.Success);
-                        }
-                        return Task.FromResult(Command.Result.Cancelled);
-                    }
-                },
-                new Command
-                {
-                    Name = "Insights", Description = () => "Configure Insights settings",
-                    SubCommands = new List<Command>
-                    {
-                        new Command
-                        {
-                            Name = "fresh days", Description = () => $"Set the number of days that counts as being 'fresh' [currently: {Program.config.Ado.Insights.FreshDays}]",
-                            Action = () =>
-                            {
-                                Program.ui.Write("Enter new number of fresh days: ");
-                                if (int.TryParse(Program.ui.ReadLine(), out var freshDays))
-                                {
-                                    Program.config.Ado.Insights.FreshDays = freshDays;
-                                    Config.Save(Program.config, Program.ConfigFilePath);
-                                    Program.ui.WriteLine($"Fresh days set to: {freshDays}");
-                                    return Task.FromResult(Command.Result.Success);
-                                }
-                                return Task.FromResult(Command.Result.Cancelled);
-                            }
-                        },
-                        new Command
-                        {
-                            Name = "soon days", Description = () => $"Set the number of days that counts for 'soon' [currently: {Program.config.Ado.Insights.SoonDays}]",
-                            Action = () =>
-                            {
-                                Program.ui.Write("Enter new number of soon days: ");
-                                if (int.TryParse(Program.ui.ReadLine(), out var soonDays))
-                                {
-                                    Program.config.Ado.Insights.SoonDays = soonDays;
-                                    Config.Save(Program.config, Program.ConfigFilePath);
-                                    Program.ui.WriteLine($"Soon days set to: {soonDays}");
-                                    return Task.FromResult(Command.Result.Success);
-                                }
-                                return Task.FromResult(Command.Result.Cancelled);
-                            }
-                        },
-                        new Command
-                        {
-                            Name = "freshness weight", Description = () => $"Set how much to weigh freshness [currently: {Program.config.Ado.Insights.W_Fresh}]",
-                            Action = () =>
-                            {
-                                Program.ui.Write("Enter new weight for fresh insights: ");
-                                if (int.TryParse(Program.ui.ReadLine(), out var weight))
-                                {
-                                    Program.config.Ado.Insights.W_Fresh = weight;
-                                    Config.Save(Program.config, Program.ConfigFilePath);
-                                    Program.ui.WriteLine($"Weight for fresh insights set to: {weight}");
-                                    return Task.FromResult(Command.Result.Success);
-                                }
-                                return Task.FromResult(Command.Result.Cancelled);
-                            }
-                        },
-                        new Command
-                        {
-                            Name = "recent change weight", Description = () => $"Set how much to weigh recent changes [currently: {Program.config.Ado.Insights.W_RecentChange}]",
-                            Action = () =>
-                            {
-                                Program.ui.Write("Enter new weight for recent changes: ");
-                                if (int.TryParse(Program.ui.ReadLine(), out var weight))
-                                {
-                                    Program.config.Ado.Insights.W_RecentChange = weight;
-                                    Config.Save(Program.config, Program.ConfigFilePath);
-                                    Program.ui.WriteLine($"Weight for recent changes set to: {weight}");
-                                    return Task.FromResult(Command.Result.Success);
-                                }
-                                return Task.FromResult(Command.Result.Cancelled);
-                            }
-                        },
-                        new Command
-                        {
-                            Name ="unassigned weight", Description = () => $"Set how much to weigh unassigned changes [currently: {Program.config.Ado.Insights.W_Unassigned}]",
-                            Action = () =>
-                            {
-                                Program.ui.Write("Enter new weight for unassigned changes: ");
-                                if (int.TryParse(Program.ui.ReadLine(), out var weight))
-                                {
-                                    Program.config.Ado.Insights.W_Unassigned = weight;
-                                    Config.Save(Program.config, Program.ConfigFilePath);
-                                    Program.ui.WriteLine($"Weight for unassigned changes set to: {weight}");
-                                    return Task.FromResult(Command.Result.Success);
-                                }
-                                return Task.FromResult(Command.Result.Cancelled);
-                            }
-                        },
-                        new Command
-                        {
-                            Name ="high priority weight", Description = () => $"Set how much to weigh high priority (P1/P2) items [currently: {Program.config.Ado.Insights.W_PriorityHigh}]",
-                            Action = () =>
-                            {
-                                Program.ui.Write("Enter new weight for high priority changes: ");
-                                if (int.TryParse(Program.ui.ReadLine(), out var weight))
-                                {
-                                    Program.config.Ado.Insights.W_PriorityHigh = weight;
-                                    Config.Save(Program.config, Program.ConfigFilePath);
-                                    Program.ui.WriteLine($"Weight for high priority changes set to: {weight}");
-                                    return Task.FromResult(Command.Result.Success);
-                                }
-                                return Task.FromResult(Command.Result.Cancelled);
-                            }
-                        },
-                        new Command
-                        {
-                            Name ="critical tag weight", Description = () => $"Set how much to weigh critical tags [currently: {Program.config.Ado.Insights.W_CriticalTag}]",
-                            Action = () =>
-                            {
-                                Program.ui.Write("Enter new weight for critical tags: ");
-                                if (int.TryParse(Program.ui.ReadLine(), out var weight))
-                                {
-                                    Program.config.Ado.Insights.W_CriticalTag = weight;
-                                    Config.Save(Program.config, Program.ConfigFilePath);
-                                    Program.ui.WriteLine($"Weight for critical tags set to: {weight}");
-                                    return Task.FromResult(Command.Result.Success);
-                                }
-                                return Task.FromResult(Command.Result.Cancelled);
-                            }
-                        },
-                        new Command
-                        {
-                            Name = "Due soon weight", Description = () => $"Set how much to weigh items due soon [currently: {Program.config.Ado.Insights.W_DueSoon}]",
-                            Action = () =>
-                            {
-                                Program.ui.Write("Enter new weight for items due soon: ");
-                                if (int.TryParse(Program.ui.ReadLine(), out var weight))
-                                {
-                                    Program.config.Ado.Insights.W_DueSoon = weight;
-                                    Config.Save(Program.config, Program.ConfigFilePath);
-                                    Program.ui.WriteLine($"Weight for items due soon set to: {weight}");
-                                    return Task.FromResult(Command.Result.Success);
-                                }
-                                return Task.FromResult(Command.Result.Cancelled);
-                            }
-                        },
-                        // CRUD commands for Critical Tags
-                        new Command
-                        {
-                            Name = "Critical Tags", Description = () => "add/remove/edit 'critical tags'",
-                            SubCommands = new List<Command>
-                            {
-                                new Command
-                                {
-                                    Name = "list", Description = () => "List current critical tags",
-                                    Action = () =>
-                                    {
-                                        Program.ui.WriteLine("Current critical tags:");
-                                        foreach (var tag in Program.config.Ado.Insights.CriticalTags)
-                                        {
-                                            Program.ui.WriteLine($" - {tag}");
-                                        }
-                                        return Task.FromResult(Command.Result.Success);
-                                    }
-                                },
-                                new Command
-                                {
-                                    Name = "add", Description = () => "Add a new critical tag",
-                                    Action = () =>
-                                    {
-                                        while (true)
-                                        {
-                                            Program.ui.Write("Enter new critical tag: ");
-                                            var tag = Program.ui.ReadLine();
-                                            if (!string.IsNullOrWhiteSpace(tag))
-                                            {
-                                                Program.config.Ado.Insights.CriticalTags.Add(tag);
-                                                Config.Save(Program.config, Program.ConfigFilePath);
-                                                Program.ui.WriteLine($"Critical tag added: {tag}");
-                                                Program.ui.WriteLine("Add another? (y/n)");
-                                                var response = Program.ui.ReadLine();
-                                                response = response?.Trim().ToLower();
-                                                if (string.IsNullOrWhiteSpace(response) || response.StartsWith("y"))
-                                                {
-                                                    continue;
-                                                }
+                        var form = UiForm.Create("Azure DevOps – Insights", Program.config.Ado.Insights);
 
-                                                return Task.FromResult(Command.Result.Success);
-                                            }
-                                            return Task.FromResult(Command.Result.Cancelled);
-                                        }
-                                    }
-                                },
-                                new Command
-                                {
-                                    Name = "remove", Description = () => "Remove a critical tag",
-                                    Action = () =>
-                                    {
-                                        while (true)
-                                        {
-                                            var choices = Program.config.Ado.Insights.CriticalTags.ToList();
-                                            var header = "Select a critical tag to remove:\n" + new string('─', Math.Max(60, Program.ui.Width - 1));
-                                            var selected = Program.ui.RenderMenu(header, choices);
+                        form.AddInt<dynamic>("Fresh Days",
+                            m => (int)(m.FreshDays),
+                            (m, v) => m.FreshDays = v, "FreshDays")
+                            .WithHelp("How many days counts as 'fresh' items.")
+                            .IntBounds(0, 365);
 
-                                            if (string.IsNullOrWhiteSpace(selected))
-                                            {
-                                                return Task.FromResult(Command.Result.Cancelled);
-                                            }
+                        form.AddInt<dynamic>("Soon Days",
+                            m => (int)(m.SoonDays),
+                            (m, v) => m.SoonDays = v, "SoonDays")
+                            .WithHelp("How many days ahead counts as 'due soon'.")
+                            .IntBounds(0, 365);
 
-                                            if (Program.config.Ado.Insights.CriticalTags.Remove(selected))
-                                            {
-                                                Config.Save(Program.config, Program.ConfigFilePath);
-                                                Program.ui.WriteLine($"Critical tag removed: {selected}");
-                                                Program.ui.WriteLine("Remove another? (y/n)");
-                                                var response = Program.ui.ReadLine();
-                                                response = response?.Trim().ToLower();
-                                                if (string.IsNullOrWhiteSpace(response) || response.StartsWith("y"))
-                                                {
-                                                    continue;
-                                                }
-                                                return Task.FromResult(Command.Result.Success);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        form.AddFloat<dynamic>("Weight: Fresh",
+                            m => (float)(m.W_Fresh),
+                            (m, v) => m.W_Fresh = v, "W_Fresh")
+                            .WithHelp("Score weight for freshness.")
+                            .IntBounds(0, 10);
+
+                        form.AddFloat<dynamic>("Weight: Recent Change",
+                            m => (float)(m.W_RecentChange),
+                            (m, v) => m.W_RecentChange = v, "W_RecentChange")
+                            .WithHelp("Score weight for items changed recently.")
+                            .IntBounds(0, 10);
+
+                        form.AddFloat<dynamic>("Weight: Unassigned",
+                            m => (float)(m.W_Unassigned),
+                            (m, v) => m.W_Unassigned = v, "W_Unassigned")
+                            .WithHelp("Score weight for unassigned items.")
+                            .IntBounds(0, 10);
+
+                        form.AddFloat<dynamic>("Weight: Priority High (P1/P2)",
+                            m => (float)(m.W_PriorityHigh),
+                            (m, v) => m.W_PriorityHigh = v, "W_PriorityHigh")
+                            .WithHelp("Score weight for high-priority items.")
+                            .IntBounds(0, 10);
+
+                        form.AddFloat<dynamic>("Weight: Critical Tag",
+                            m => (float)(m.W_CriticalTag),
+                            (m, v) => m.W_CriticalTag = v, "W_CriticalTag")
+                            .WithHelp("Score weight for presence of critical tags.")
+                            .IntBounds(0, 10);
+
+                        form.AddFloat<dynamic>("Weight: Due Soon",
+                            m => (float)(m.W_DueSoon),
+                            (m, v) => m.W_DueSoon = v, "W_DueSoon")
+                            .WithHelp("Score weight for approaching due dates.")
+                            .IntBounds(0, 10);
+
+                        // Inline editor for CriticalTags (List<string>) using the Array field
+                        form.AddList<dynamic, string>("Critical Tags",
+                            m => (IList<string>)(m.CriticalTags ?? new List<string>()),
+                            (m, v) => m.CriticalTags = v?.ToList() ?? new List<string>(),
+                            "CriticalTags")
+                            .WithHelp("Tags treated as 'critical' (add/remove/edit; JSON-backed).")
+                            .MakeOptional();
+
+                        if (!await Program.ui.ShowFormAsync(form))
+                            return Command.Result.Cancelled;
+
+                        Program.config.Ado.Insights = (AdoInsightsConfig)form.Model!;
+
+                        Config.Save(Program.config, Program.ConfigFilePath);
+                        Program.ui.WriteLine("ADO insights saved.");
+                        return Command.Result.Success;
                     }
                 }
             }

--- a/Subsytems/ADO/UserSelectedQuery.cs
+++ b/Subsytems/ADO/UserSelectedQuery.cs
@@ -7,13 +7,13 @@ public class UserSelectedQuery
     [UserField(required: true)]
     public Guid Id { get; set; }
     
-    [UserField(required: true)]
+    [UserField(required: true, FieldKind = UiFieldKind.String)]
     public string Name { get; set; } = string.Empty;
     
-    [UserField(required: true)]
+    [UserField(required: true, FieldKind = UiFieldKind.String)]
     public string Project { get; set; } = string.Empty;
     
-    [UserField(required: true)]
+    [UserField(required: true, FieldKind = UiFieldKind.String)]
     public string Path { get; set; } = string.Empty;
 
     public UserSelectedQuery() { }

--- a/Subsytems/Kusto/KustoConfig.cs
+++ b/Subsytems/Kusto/KustoConfig.cs
@@ -16,15 +16,16 @@ public sealed class KustoConfig
     [UserKey]
     public string Name { get; set; } = "";
 
-    [UserField(required: true, display: "Cluster URI")]
+    [UserField(required: true, display: "Cluster URI", FieldKind = UiFieldKind.String, Placeholder = "https://cluster.region.kusto.windows.net")]
     public string ClusterUri { get; set; } = "";
 
-    [UserField(required: true, display: "Database Name")]
+    [UserField(required: true, display: "Database Name", FieldKind = UiFieldKind.String, Placeholder = "<database>")]
     public string Database { get; set; } = "";
 
-    [UserField(required: true, display: "Authentication method", hint: "devicecode|prompt|azcli|managedIdentity")]
+    [UserField(required: true, display: "Authentication method")]
     public KustoAuthMode AuthMode { get; set; } = KustoAuthMode.devicecode;
 
+    [UserField(required: true, display: "Default Query Timeout (seconds)", FieldKind = UiFieldKind.Number, Placeholder = "30", Hint = "Timeout in seconds for Kusto queries")]
     public int DefaultTimeoutSeconds { get; set; } = 60;
 
     public List<KustoQuery> Queries { get; set; } = new();        // child items

--- a/Subsytems/MAPI/MailUserData.cs
+++ b/Subsytems/MAPI/MailUserData.cs
@@ -5,9 +5,9 @@ using System.Collections.Generic;
 public class FavoriteMailFolder
 {
     [UserKey]
-    [UserField(required: true)] public string IdOrName { get; set; } = string.Empty;
+    [UserField(required: true, FieldKind = UiFieldKind.String)] public string IdOrName { get; set; } = string.Empty;
 
-    [UserField(required: true)] public string DisplayName { get; set; } = string.Empty;
+    [UserField(required: true, FieldKind = UiFieldKind.String)] public string DisplayName { get; set; } = string.Empty;
 
     public FavoriteMailFolder() { }
 
@@ -24,12 +24,12 @@ public class FavoriteMailFolder
 public class MailTopic
 {
     [UserKey]
-    [UserField(required: true)] public string Name { get; set; } = string.Empty;
+    [UserField(required: true, FieldKind = UiFieldKind.String)] public string Name { get; set; } = string.Empty;
 
-    [UserField(required: true)] public string Description { get; set; } = string.Empty;
+    [UserField(required: true, FieldKind = UiFieldKind.Text)] public string Description { get; set; } = string.Empty;
 
     // Comma- or newline-separated keywords/phrases used to match emails into this topic
-    [UserField(required: true)] public string Keywords { get; set; } = string.Empty;
+    [UserField(required: true, FieldKind = UiFieldKind.String)] public string Keywords { get; set; } = string.Empty;
 
     public override string ToString() => $"{Name} — {Description}";
 }

--- a/Subsytems/PRs/PRsCommands.cs
+++ b/Subsytems/PRs/PRsCommands.cs
@@ -6,6 +6,9 @@ using System.Collections.Generic;
 
 public static class PRsCommands
 {
+    private class PRsWindowModel { public int Window { get; set; } = 14; }
+    private class PRsLimitModel { public int Limit { get; set; } = 25; }
+    private class PRsMaxModel { public int Max { get; set; } = 2; }
     public static Command Commands(PRsClient prs)
     {
         return new Command
@@ -28,7 +31,10 @@ public static class PRsCommands
                     Name = "report", Description = () => "Manager report (recent window: counts + linkable bullets)",
                     Action = async () => {
                         var prof = PickProfile(); if (prof is null) return Command.Result.Failed;
-                        Program.ui.Write("Window (days, default 14): "); var w = int.TryParse(Program.ui.ReadLineWithHistory(), out var vv) ? vv : 14;
+                        var winForm = UiForm.Create("Report options", new PRsWindowModel { Window = 14 });
+                        winForm.AddInt<PRsWindowModel>("WindowDays", m => m.Window, (m,v)=> m.Window = v).IntBounds(1,60).WithHelp("Days back (1-60).");
+                        if (!await Program.ui.ShowFormAsync(winForm)) { return Command.Result.Cancelled; }
+                        var w = ((PRsWindowModel)winForm.Model!).Window;
                         var resp = await ToolRegistry.InvokeToolAsync("tool.prs.report",
                             new ReportPRsInput { ProfileName = prof.Name, WindowDays = w });
                         Program.ui.WriteLine(resp);
@@ -42,7 +48,10 @@ public static class PRsCommands
                         var sliceNames = new[]{"stale","new","closed"};
                         var sel = Program.ui.RenderMenu("Pick slice:", sliceNames.ToList());
                         var chosen = sel ?? sliceNames[0];
-                        Program.ui.Write("Limit (default 25): "); var lim = int.TryParse(Program.ui.ReadLineWithHistory(), out var lv) ? lv : 25;
+                        var sliceForm = UiForm.Create("Slice options", new PRsLimitModel { Limit = 25 });
+                        sliceForm.AddInt<PRsLimitModel>("Limit", m => m.Limit, (m,v)=> m.Limit = v).IntBounds(1,500).WithHelp("Max items (1-500).");
+                        if (!await Program.ui.ShowFormAsync(sliceForm)) { return Command.Result.Cancelled; }
+                        var lim = ((PRsLimitModel)sliceForm.Model!).Limit;
                         var resp = await ToolRegistry.InvokeToolAsync("tool.prs.slice",
                             new SlicePRsInput { ProfileName = prof.Name, Slice = chosen, Limit = lim });
                         Program.ui.WriteLine(resp);
@@ -53,7 +62,10 @@ public static class PRsCommands
                     Name = "coach", Description = () => "Analyze PR comment threads and suggest coaching points",
                     Action = async () => {
                         var prof = PickProfile(); if (prof is null) return Command.Result.Failed;
-                        Program.ui.Write("Max PRs per IC to analyze (default 2; newest first): "); var m = int.TryParse(Program.ui.ReadLineWithHistory(), out var mv) ? mv : 2;
+                        var coachForm = UiForm.Create("Coach options", new PRsMaxModel { Max = 2 });
+                        coachForm.AddInt<PRsMaxModel>("MaxPerIC", m => m.Max, (m,v)=> m.Max = v).IntBounds(1,10).WithHelp("Max PRs per IC (1-10).");
+                        if (!await Program.ui.ShowFormAsync(coachForm)) { return Command.Result.Cancelled; }
+                        var m = ((PRsMaxModel)coachForm.Model!).Max;
                         var resp = await ToolRegistry.InvokeToolAsync("tool.prs.coach",
                             new CoachPRsInput { ProfileName = prof.Name, MaxPerIC = m });
                         Program.ui.WriteLine(resp);

--- a/Subsytems/S360/S360Client.cs
+++ b/Subsytems/S360/S360Client.cs
@@ -1,7 +1,4 @@
 using System.Linq;
-using System.Text.Json;
-using System.Text.Json.Nodes;
-
 
 [IsConfigurable("S360")]
 [DependsOn("Kusto")]

--- a/Subsytems/S360/S360Commands.cs
+++ b/Subsytems/S360/S360Commands.cs
@@ -28,7 +28,16 @@ public static class S360Commands
                     Name = "triage", Description = () => "Score & summarize (briefing + action plan)",
                     Action = async () => {
                         var prof = PickProfile(); if (prof is null) return Command.Result.Failed;
-                        Program.ui.Write("Top N (default 15): "); var n = int.TryParse(Program.ui.ReadLineWithHistory(), out var v) ? v : 15;
+
+                        var form = UiForm.Create("Triage options", 15);
+                        form.AddInt("Top N")
+                            .IntBounds(min: 1, max: 100)
+                            .WithHelp("Number of top action items to include in the summary, range is 1 to 100.");
+
+                        if (!await Program.ui.ShowFormAsync(form)){
+                            return Command.Result.Cancelled;
+                        }
+                        var n = (int)form.Model!;
                         var resp = await ToolRegistry.InvokeToolAsync("tool.s360.triage",
                             new TriageS360Input { ProfileName = prof.Name, TopN = n });
                         Program.ui.WriteLine(resp);

--- a/Tools/file_system.cs
+++ b/Tools/file_system.cs
@@ -27,9 +27,10 @@ public class file_list : ITool
             return ToolResult.Failure($"ERROR: Directory not found: {path}", Context);
         }
 
-        var supportedTypes = Engine.SupportedFileTypes;
+        Engine.RefreshSupportedFileTypesFromUserManaged();
+        var allowed = Engine.SupportedFileTypes; // already filtered for Enabled
         var files = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories)
-            .Where(f => supportedTypes.Contains(Path.GetExtension(f), StringComparer.OrdinalIgnoreCase))
+            .Where(f => allowed.Contains(Path.GetExtension(f), StringComparer.OrdinalIgnoreCase))
             .ToList();
 
         var list = string.Join("\n", files.Select(f => Path.GetRelativePath(path, f)));

--- a/UX/IUI.cs
+++ b/UX/IUI.cs
@@ -1,9 +1,278 @@
 using System;
+using System.Collections.Generic;
+
+public enum UiFieldKind { String, Number, Guid, Enum, Bool }
+
+public interface IUiField
+{
+    string Label { get; }
+    UiFieldKind Kind { get; }
+    bool Required { get; }
+    string? Help { get; }
+
+    // formatter: produce a display string for the current field value from a model object
+    Func<object?, string> Formatter { get; }
+
+    IEnumerable<string>? EnumChoices();           // only for Kind == Enum
+    int? MinInt();                                // only for Kind == Int
+    int? MaxInt();                                // only for Kind == Int
+
+    // Host → apply the user-entered value to the model clone.
+    // 'value' is the raw string coming back from UI; TrySet parses & validates.
+    // Return true when successfully set; else set error with message to display/log.
+    bool TrySetFromString(object model, string? value, out string? error);
+
+    // Fluent setters for constraints & help (return non-generic for ease of chaining when model type isn't required)
+    IUiField WithHelp(string? help);
+    IUiField IntBounds(int? min = null, int? max = null);
+    IUiField FormatWith(Func<object?, string> format); // custom formatting
+    IUiField MakeOptional(); // Fields are required by default. Call MakeOptional() to mark a field optional.
+}
+
+public sealed class UiField<TModel, TValue> : IUiField
+{
+    public string Label { get; }
+    public UiFieldKind Kind { get; }
+    public bool Required { get; set; } = true; // Fields are required by default
+    public string? Help { get; set; }
+
+    // constraints/choices
+    public int? Min { get; set; }
+    public int? Max { get; set; }
+    public IReadOnlyList<string>? Choices { get; set; } // for enums
+
+    // projection
+    private readonly Func<TModel, TValue> _get;
+    private readonly Action<TModel, TValue> _set;
+
+    // parsing/formatting
+    private readonly Func<string?, (bool ok, TValue? value, string? error)> _tryParse;
+    private Func<TValue?, string> _format;
+
+    public UiField(
+        string label,
+        UiFieldKind kind,
+        Func<TModel, TValue> get,
+        Action<TModel, TValue> set,
+        Func<string?, (bool ok, TValue? value, string? error)> tryParse)
+    {
+        Label = label;
+        Kind = kind;
+        _get = get;
+        _set = set;
+        _tryParse = tryParse;
+        _format = v => v?.ToString() ?? "";
+
+        if (UiFieldKind.Enum == kind)
+        {
+            Choices = Enum.GetValues(typeof(TValue)) is TValue[] arr
+                ? Array.ConvertAll(arr, v => v?.ToString() ?? "")
+                : null;
+        }
+    }
+
+    // formatter uses typed getter + typed formatter
+    public Func<object?, string> Formatter => model => _format(_get((TModel)model!));
+
+    public IEnumerable<string>? EnumChoices() => Choices;
+    public int? MinInt() => Min;
+    public int? MaxInt() => Max;
+
+    public bool TrySetFromString(TModel model, string? value, out string? error)
+    {
+        var (result, err) = Log.Method(ctx =>
+        {
+            ctx.OnlyEmitOnFailure()
+                .Append(Log.Data.Input, value ?? "<null>")
+                .Append(Log.Data.TypeToParse, Kind.ToString());
+
+            if (Required && string.IsNullOrWhiteSpace(value))
+            {
+                ctx.Append(Log.Data.Message, $"Field [{Label}] is required.");
+                return (false, "This field is required.");
+            }
+            var (ok, parsed, err) = _tryParse(value);
+            if (!ok)
+            {
+                ctx.Append(Log.Data.Message, err ?? "Invalid value.");
+                return (false, err ?? "Invalid value.");
+            }
+            if (Kind == UiFieldKind.Number)
+            {
+                if (parsed is int n)
+                {
+                    if (Min is int min && n < min)
+                    {
+                        ctx.Append(Log.Data.Message, $"Int must be ≥ {min}.");
+                        return (false, $"Int must be ≥ {min}.");
+                    }
+                    if (Max is int max && n > max)
+                    {
+                        ctx.Append(Log.Data.Message, $"Int must be ≤ {max}.");
+                        return (false, $"Int must be ≤ {max}.");
+                    }
+                }
+                else if (parsed is double d)
+                {
+                    if (Min is int min && d < min)
+                    {
+                        ctx.Append(Log.Data.Message, $"Double must be ≥ {min}.");
+                        return (false, $"Double must be ≥ {min}.");
+                    }
+                    if (Max is int max && d > max)
+                    {
+                        ctx.Append(Log.Data.Message, $"Double must be ≤ {max}.");
+                        return (false, $"Double must be ≤ {max}.");
+                    }
+                }
+                else if (parsed is float f)
+                {
+                    if (Min is int min && f < min)
+                    {
+                        ctx.Append(Log.Data.Message, $"Float must be ≥ {min}.");
+                        return (false, $"Float must be ≥ {min}.");
+                    }
+                    if (Max is int max && f > max)
+                    {
+                        ctx.Append(Log.Data.Message, $"Float must be ≤ {max}.");
+                        return (false, $"Float must be ≤ {max}.");
+                    }
+                }
+            }
+
+            _set(model, parsed!);
+            ctx.Succeeded();
+            return (true, string.Empty);
+        });
+        error = string.IsNullOrEmpty(err) ? null : err;
+        return result;
+    }
+
+    // non-generic wrapper
+    bool IUiField.TrySetFromString(object model, string? value, out string? error)
+        => TrySetFromString((TModel)model!, value, out error);
+    public UiField<TModel, TValue> WithHelp(string? help) { Help = help; return this; }
+    public UiField<TModel, TValue> MakeOptional() { Required = false; return this; } // Switches default required behavior; fields are required unless made optional.
+    public UiField<TModel, TValue> IntBounds(int? min = null, int? max = null) { Min = min; Max = max; return this; }
+    public UiField<TModel, TValue> FormatWith(Func<object?, string> format) { _format = v => format(v); return this; }
+
+    // non-generic fluent wrappers
+    IUiField IUiField.WithHelp(string? help) { WithHelp(help); return this; }
+    IUiField IUiField.MakeOptional() { MakeOptional(); return this; }
+    IUiField IUiField.IntBounds(int? min, int? max) { IntBounds(min, max); return this; }
+    IUiField IUiField.FormatWith(Func<object?, string> format) { FormatWith(format); return this; }
+}
+public sealed class UiForm
+{
+    public string Title { get; init; } = "Input";
+    public object? Model { get; set; } // the form holds a cloned model as object; fields' formatters and TrySetFromString use this model
+    public List<IUiField> Fields { get; } = new();
+
+    private UiForm(object? clone) { Model = clone; }
+
+    // Factory: Super important to clone the original value, don't trust the caller to get it right!
+    public static UiForm Create<TModel>(string title, TModel original)
+        => new(original!.ToJson()!.FromJson<TModel>()!) { Title = title };
+
+    private IUiField Add(IUiField field) { Fields.Add(field); return field; }
+    private IUiField Add<TModel, TValue>(UiField<TModel, TValue> field) { Fields.Add(field); return field; }
+
+    public IUiField AddString<TModel>(string label, Func<TModel, string> get, Action<TModel, string> set)
+        => Add(new UiField<TModel, string>(label, UiFieldKind.String, get, set,
+               s => (true, s ?? "", null)));
+
+    // Convenience overload when the form's Model is the same as the field type
+    public IUiField AddString(string label)
+        => AddString<string>(label,
+            m => Model is string sv ? sv : (Model as object)?.ToString() ?? string.Empty,
+            (m, v) => Model = v);
+
+    public IUiField AddInt<TModel>(string label, Func<TModel, int> get, Action<TModel, int> set)
+        => Add(new UiField<TModel, int>(label, UiFieldKind.Number, get, set,
+               s => int.TryParse(s, out var v)
+                        ? (true, v, null)
+                        : (false, default, "Enter a whole number.")));
+
+    // Convenience overload when the form's Model is int
+    public IUiField AddInt(string label)
+        => AddInt<int>(label,
+            m => Model is int iv ? iv : throw new InvalidOperationException($"UiForm.AddInt() can only be used when Model is int."),
+            (m, v) => Model = v);
+
+    public IUiField AddFloat<TModel>(string label, Func<TModel, float> get, Action<TModel, float> set)
+        => Add(new UiField<TModel, float>(label, UiFieldKind.Number, get, set,
+               s => float.TryParse(s, out var v)
+                        ? (true, v, null)
+                        : (false, default, "Enter a valid floating-point number.")));
+
+    // Convenience overload when Model is float
+    public IUiField AddFloat(string label)
+        => AddFloat<float>(label,
+            m => Model is float fv ? fv : throw new InvalidOperationException($"UiForm.AddFloat() can only be used when Model is float."),
+            (m, v) => Model = v);
+
+    public IUiField AddDouble<TModel>(string label, Func<TModel, double> get, Action<TModel, double> set)
+        => Add(new UiField<TModel, double>(label, UiFieldKind.Number, get, set,
+               s => double.TryParse(s, out var v)
+                        ? (true, v, null)
+                        : (false, default, "Enter a valid double precision number.")));
+
+    // Convenience overload when Model is double
+    public IUiField AddDouble(string label)
+        => AddDouble<double>(label,
+            m => Model is double dv ? dv : throw new InvalidOperationException($"UiForm.AddDouble() can only be used when Model is double."),
+            (m, v) => Model = v);
+
+    public IUiField AddBool<TModel>(string label, Func<TModel, bool> get, Action<TModel, bool> set)
+        => Add(new UiField<TModel, bool>(label, UiFieldKind.Bool, get, set,
+               s => bool.TryParse(s, out var v)
+                        ? (true, v, null)
+                        : (false, default, "Enter true or false.")));
+
+    // Convenience overload when Model is bool
+    public IUiField AddBool(string label)
+        => AddBool<bool>(label,
+            m => Model is bool bv ? bv : throw new InvalidOperationException($"UiForm.AddBool() can only be used when Model is bool."),
+            (m, v) => Model = v);
+
+    public IUiField AddGuid<TModel>(string label, Func<TModel, Guid> get, Action<TModel, Guid> set)
+        => Add(new UiField<TModel, Guid>(label, UiFieldKind.Guid, get, set,
+               s => System.Guid.TryParse(s, out var v)
+                        ? (true, v, null)
+                        : (false, default, "Enter a valid GUID.")));
+
+    // Convenience overload when Model is Guid
+    public IUiField AddGuid(string label)
+        => AddGuid<Guid>(label,
+            m => Model is Guid gv ? gv : throw new InvalidOperationException($"UiForm.AddGuid() can only be used when Model is Guid."),
+            (m, v) => Model = v);
+
+    public IUiField AddEnum<TModel>(string label, Type enumType, Func<TModel, string> get, Action<TModel, string> set)
+        => Add(new UiField<TModel, string>(label, UiFieldKind.Enum, get, set,
+               s => (Enum.IsDefined(enumType, s ?? "") ? (true, s, null) : (false, default, $"Must be one of: {string.Join(", ", Enum.GetNames(enumType))}"))));
+
+    // Convenience overload when Model is the enum type itself or a string to hold the enum name
+    public IUiField AddEnum(string label, Type enumType)
+        => AddEnum<string>(label, enumType,
+            m => Model is string sv ? sv : Model is Enum e ? e.ToString() : throw new InvalidOperationException($"UiForm.AddEnum() requires Model to be either string or an enum type."),
+            (m, v) =>
+            {
+                if (Model is string) Model = v;
+                else if (Model is Enum)
+                {
+                    var enumValue = Enum.Parse(enumType, v ?? "");
+                    Model = enumValue;
+                }
+                else throw new InvalidOperationException($"UiForm.AddEnum() requires Model to be either string or an enum type.");
+            });
+}
 
 public interface IUi
 {
-    // input
+    // high-level I/O
+    Task<bool> ShowFormAsync(UiForm form);
 
+    // input
     Task<string?> ReadPathWithAutocompleteAsync(bool isDirectory);
     Task<string?> ReadInputWithFeaturesAsync(CommandManager commandManager);
     string? RenderMenu(string header, List<string> choices, int selected = 0);
@@ -15,10 +284,7 @@ public interface IUi
     void RenderChatMessage(ChatMessage message);
     void RenderChatHistory(IEnumerable<ChatMessage> messages);
 
-    // lifecycle helpers
-    void BeginUpdate();
-    void EndUpdate();
-
+    // low-level console-like I/O (to be removed)
     int CursorTop { get; }
     int CursorLeft { get; }
     int Width { get; }

--- a/UX/IUI.cs
+++ b/UX/IUI.cs
@@ -260,13 +260,13 @@ public sealed class UiForm
         => AddInt<int>(label, m => Model is int iv ? iv : throw new InvalidOperationException("UiForm.AddInt requires int Model."), (m, v) => Model = v, key);
 
     public IUiField AddFloat<TModel>(string label, Func<TModel, float> get, Action<TModel, float> set, string? key = null)
-        => Add(new UiField<TModel, float>(key ?? Fields.Count.ToString(), label, UiFieldKind.Number, get, set,
+        => Add(new UiField<TModel, float>(key ?? Fields.Count.ToString(), label, UiFieldKind.Decimal, get, set,
                s => float.TryParse(s, out var v) ? (true, v, null) : (false, default, "Enter a valid floating-point number.")));
     public IUiField AddFloat(string label, string? key = null)
         => AddFloat<float>(label, m => Model is float fv ? fv : throw new InvalidOperationException("UiForm.AddFloat requires float Model."), (m, v) => Model = v, key);
 
     public IUiField AddDouble<TModel>(string label, Func<TModel, double> get, Action<TModel, double> set, string? key = null)
-        => Add(new UiField<TModel, double>(key ?? Fields.Count.ToString(), label, UiFieldKind.Number, get, set,
+        => Add(new UiField<TModel, double>(key ?? Fields.Count.ToString(), label, UiFieldKind.Decimal, get, set,
                s => double.TryParse(s, out var v) ? (true, v, null) : (false, default, "Enter a valid double precision number.")));
     public IUiField AddDouble(string label, string? key = null)
         => AddDouble<double>(label, m => Model is double dv ? dv : throw new InvalidOperationException("UiForm.AddDouble requires double Model."), (m, v) => Model = v, key);

--- a/UX/IUI.cs
+++ b/UX/IUI.cs
@@ -299,13 +299,13 @@ public interface IUi
 {
     // high-level I/O
     Task<bool> ShowFormAsync(UiForm form);
+    // simple yes/no confirmation (true=yes, false=no). Blank input chooses defaultAnswer.
+    Task<bool> ConfirmAsync(string question, bool defaultAnswer = false);
 
     // input
     Task<string?> ReadPathWithAutocompleteAsync(bool isDirectory);
     Task<string?> ReadInputWithFeaturesAsync(CommandManager commandManager);
     string? RenderMenu(string header, List<string> choices, int selected = 0);
-    string? ReadLineWithHistory();
-    string ReadLine();
     ConsoleKeyInfo ReadKey(bool intercept);
 
     // output

--- a/UX/Terminal.cs
+++ b/UX/Terminal.cs
@@ -6,6 +6,20 @@ public class Terminal : IUi
 {
     private string? lastInput = null;
 
+    public Task<bool> ConfirmAsync(string question, bool defaultAnswer = false)
+    {
+        Write($"{question} {(defaultAnswer ? "[Y/n]" : "[y/N]")} ");
+        while (true)
+        {
+            var input = Console.ReadLine() ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(input)) return Task.FromResult(defaultAnswer);
+            input = input.Trim().ToLowerInvariant();
+            if (input == "y" || input == "yes") return Task.FromResult(true);
+            if (input == "n" || input == "no") return Task.FromResult(false);
+            Write("Please enter y or n: ");
+        }
+    }
+
     public async Task<bool> ShowFormAsync(UiForm form)
     {
         await Task.CompletedTask;
@@ -447,70 +461,6 @@ public class Terminal : IUi
             }
         }
     }
-
-    public string? ReadLineWithHistory()
-    {
-        var buffer = new List<char>();
-        int cursor = 0;
-        ConsoleKeyInfo key;
-
-        while (true)
-        {
-            key = ReadKey(intercept: true);
-
-            if (key.Key == ConsoleKey.Enter)
-            {
-                WriteLine();
-                break;
-            }
-            else if (key.Key == ConsoleKey.Backspace)
-            {
-                if (cursor > 0)
-                {
-                    buffer.RemoveAt(cursor - 1);
-                    cursor--;
-                    Write("\b \b");
-                }
-            }
-            else if (key.Key == ConsoleKey.UpArrow)
-            {
-                if (lastInput != null)
-                {
-                    // Clear current buffer display
-                    for (int i = 0; i < buffer.Count; i++)
-                    {
-                        Write("\b \b");
-                    }
-
-                    // Set buffer to last input
-                    buffer.Clear();
-                    buffer.AddRange(lastInput.ToCharArray());
-                    cursor = buffer.Count;
-
-                    // Display the recalled input
-                    Write(lastInput);
-                }
-            }
-            else if (key.KeyChar != '\0' && !char.IsControl(key.KeyChar))
-            {
-                buffer.Insert(cursor, key.KeyChar);
-                cursor++;
-                Write(key.KeyChar.ToString());
-            }
-        }
-
-        var input = new string(buffer.ToArray()).Trim();
-
-        // Store the input for history if it's not empty
-        if (!string.IsNullOrWhiteSpace(input))
-        {
-            lastInput = input;
-        }
-
-        return string.IsNullOrWhiteSpace(input) ? null : input;
-    }
-
-    public string ReadLine() => Console.ReadLine() ?? string.Empty;
 
     public ConsoleKeyInfo ReadKey(bool intercept) => Console.ReadKey(intercept);
 

--- a/UX/wwwroot/index.html
+++ b/UX/wwwroot/index.html
@@ -211,17 +211,61 @@
 	#menuOverlay.active ~ #menuTab {
 		display: none;
 	}
+
+	#formOverlay {
+		position:fixed;
+		inset:0;
+		display:none;
+		align-items:center;
+		justify-content:center;
+		background:rgba(0,0,0,.55);
+		z-index:10000;
+	}
+
+	#formPanel {
+		background:#fff;
+		color:#000;
+		width:min(840px,92vw);
+		max-height:min(80vh,720px);
+		display:grid;
+		grid-template-rows:auto 1fr auto;
+		border-radius:12px;
+		overflow:hidden;
+		box-shadow:0 30px 70px rgba(0,0,0,.45);
+	}
+
+	#formTitle {
+		padding:14px 16px;
+		background:#111;
+		color:#eee;
+		font-weight:700;
+	}
+
+	#formBody {
+		overflow:auto;
+		padding:12px 16px;
+	}
+
+	#formFooter {
+		padding:10px 16px;
+		display:flex;
+		gap:8px;
+		justify-content:flex-end;
+		border-top:1px solid #eee;
+		background:#fafafa;
+	}
+
 </style>
 <body>
-  <header></header>
-  <div id="menuTab">press ESC key to open</div>
-  <div id='main'>
+	<header></header>
+	<div id="menuTab">press ESC key to open</div>
+	<div id='main'>
 	<div id='console'></div> <!-- big scrollable console/log -->
-  </div>
-  <div id='composer'>
+	</div>
+	<div id='composer'>
 	<input id='t' placeholder='Type and press Enter'/>
 	<button id='send'>Send</button>
-  </div>
+	</div>
 	<!-- MENU OVERLAY -->
 	<div id="menuOverlay" hidden>
 		<div id="menuPanel">
@@ -231,6 +275,17 @@
 			<div id="menuHint">↑/↓ select • Enter choose • Esc back/cancel</div>
 		</div>
 	</div>
+	<!-- FORM OVERLAY -->
+	<div id="formOverlay" hidden>
+		<div id="formPanel">
+			<div id="formTitle"></div>
+			<div id="formBody"></div>
+			<div id="formFooter">
+				<button id="formCancel">Cancel</button>
+				<button id="formSubmit" disabled>Submit</button>
+			</div>
+		</div>
+	</div>	
 <script src="marked.min.js"></script>
 <script>
 	const consoleEl = document.getElementById('console');
@@ -378,6 +433,118 @@
 		if (e.target === menuOverlay) closeMenu(null);
 	});
 	// --- end menu controller ------------------------------------------------------
+	// --- form controller ---------------------------------------------------------
+	const formOverlay = document.getElementById('formOverlay');
+	const formTitle   = document.getElementById('formTitle');
+	const formBody    = document.getElementById('formBody');
+	const formCancel  = document.getElementById('formCancel');
+	const formSubmit  = document.getElementById('formSubmit');
+	let formState = null;
+
+	function openForm(payload) {
+		formTitle.textContent = payload.title || 'Input';
+		formBody.innerHTML = '';
+		formOverlay.style.display = 'flex';
+		document.body.style.overflow = 'hidden';
+
+		const fields = (payload.fields || []).map(f => ({ ...f, id: 'f_' + Math.random().toString(36).slice(2) }));
+		formState = { fields };
+
+		for (const f of fields) {
+			const row = document.createElement('div');
+			row.style.display = 'grid';
+			row.style.gridTemplateColumns = '220px 1fr';
+			row.style.columnGap = '12px';
+			row.style.rowGap = '2px';
+			row.style.marginBottom = '12px';
+			row.style.alignItems = 'center';
+
+			const lab = document.createElement('label');
+			lab.textContent = f.label + (f.required ? ' *' : '');
+			lab.setAttribute('for', f.id);
+			row.appendChild(lab);
+
+			let input;
+			if (f.kind === 'Number') {
+				input = document.createElement('input');
+				input.type = 'number';
+				if (f.min != null) input.min = String(f.min);
+				if (f.max != null) input.max = String(f.max);
+				input.value = f.current ?? '';
+			} else if (f.kind === 'Bool') {
+				input = document.createElement('select');
+				['false','true'].forEach(v => { const o = document.createElement('option'); o.value=v; o.textContent=v; input.appendChild(o); });
+				input.value = String(f.current ?? 'false');
+			} else if (f.kind === 'Enum') {
+				input = document.createElement('select');
+				(f.choices || []).forEach(v => { const o = document.createElement('option'); o.value=v; o.textContent=v; input.appendChild(o); });
+				if (f.current != null) input.value = String(f.current);
+			} else {
+				input = document.createElement('input');
+				input.type = 'text';
+				input.value = f.current ?? '';
+			}
+			input.id = f.id;
+			input.dataset.required = f.required ? '1' : '0';
+			row.appendChild(input);
+
+			const help = document.createElement('div');
+			help.textContent = f.help || '';
+			help.style.gridColumn = '1 / span 2';
+			help.style.color = '#555';
+			help.style.fontSize = '.92em';
+			help.style.padding = '4px 2px 0 2px';
+			row.appendChild(help);
+
+			formBody.appendChild(row);
+
+			input.addEventListener('keydown', e => {
+				if (e.key === 'Enter' && input.tagName === 'INPUT') {
+					e.preventDefault();
+					const next = formBody.querySelectorAll('input,select');
+					const idx = Array.prototype.indexOf.call(next, input);
+					(next[idx + 1] || formSubmit).focus();
+				}
+			});
+			input.addEventListener('input', validateForm);
+			input.addEventListener('change', validateForm);
+		}
+
+		validateForm();
+		(formBody.querySelector('input,select') || formSubmit).focus();
+	}
+
+	function validateForm() {
+		const inputs = [...formBody.querySelectorAll('input,select')];
+		let ok = true;
+		for (const el of inputs) {
+			const required = el.dataset.required === '1';
+			const v = (el.tagName === 'SELECT') ? el.value : el.value.trim();
+			if (required && !v) { ok = false; break; }
+		}
+		formSubmit.disabled = !ok;
+	}
+
+	function closeForm(ok) {
+		if (!ok) {
+			post({ type: 'FormResult', ok: false });
+		} else {
+			const values = {};
+			for (const f of formState.fields) {
+				const el = document.getElementById(f.id);
+				values[f.label] = (el.tagName === 'SELECT') ? el.value : el.value;
+			}
+			post({ type: 'FormResult', ok: true, values });
+		}
+		formOverlay.style.display = 'none';
+		document.body.style.overflow = '';
+		formState = null;
+	}
+
+	formCancel.onclick = () => closeForm(false);
+	formSubmit.onclick = () => closeForm(true);
+	formOverlay.addEventListener('click', e => { if (e.target === formOverlay) closeForm(false); });
+	// --- end form controller ------------------------------------------------------
 
 	// --- unified handler for ANY host→page message ---
 	function handle(raw) {
@@ -392,6 +559,7 @@
 				case 'ConsoleWrite': cwrite(msg.text||''); break;
 				case 'ConsoleWriteLine': cwriteline(msg.text||''); break;
 				case 'ShowMenu': openMenu(msg); break;
+				case 'ShowForm': openForm(msg); break;
 				case 'PromptLine': post({ type:'UserText', text: prompt('Input:', msg.placeholder||'') || '' }); break;
 				case 'PromptPath': post({ type:'UserText', text: prompt('Path:', '') || '' }); break;
 				case 'FocusInput': t.focus(); break;

--- a/UX/wwwroot/index.html
+++ b/UX/wwwroot/index.html
@@ -5,266 +5,59 @@
 <title>CSChat</title>
 <style>
 	:root { --bg:#111; --fg:#eee; }
+	html, body { height: 100%; margin: 0; overflow: hidden; }
+	body { display: grid; grid-template-rows: auto 1fr auto; }
+	#main { display:flex; flex-direction:column; min-height:0; }
+	#console { display:flex; flex-direction:column; align-items:flex-start; gap:10px; flex:1; min-height:0; overflow:auto; padding:12px; }
+	#composer { display:flex; gap:8px; padding:8px 12px; border-top:none; background:transparent; }
+	#t{ flex:1; font:inherit; padding:10px 14px; border:1px solid #d9d9d9; border-radius:9999px; outline:none; background:#fff; box-shadow: inset 0 1px 2px rgba(0,0,0,.06); }
+	#t:focus{ border-color:#b9cdfd; box-shadow:0 0 0 2px rgba(80,140,255,.15), inset 0 1px 2px rgba(0,0,0,.06); }
+	#send{ padding:8px 14px; border:1px solid #d9d9d9; border-radius:9999px; background:#f6f6f6; font:inherit; cursor:pointer;}
+	#send:hover{background:#f0f0f0;} #send:active{background:#eaeaea;}
+	pre{margin:0 0 8px 0; white-space:pre-wrap;}
+	#console>.bubble{ white-space:normal; margin:0; padding:10px 12px; border-radius:10px; line-height:1.35; word-break:break-word; background:#1b1b1b; border:1px solid #333; color:var(--fg); max-width:min(70ch,70%); align-self:flex-start; font-family:system-ui,sans-serif; }
+	#console .bubble>:first-child{margin-top:0;} #console .bubble>:last-child{margin-bottom:0;}
+	#console>.bubble.user{ align-self:flex-end; background:#1d80ea; border-color:#1d80ea; color:#fafafa;}
+	#console>.bubble.assistant{ background:#ddd; border-color:#ddd; color:#000;}
+	#console>.bubble.tool{ align-self:stretch; width:100%; max-width:none; text-align:center; background:#111; border-color:#666; font-weight:600;}
+	#console>.bubble.system{ align-self:stretch; max-width:80%; background:#1a1a1a; border-style:dashed; color:#aaa;}
 
-	/* Prevent page/window scrolling; we’ll scroll the console only */
-	html, body {
-		height: 100%;
-		margin: 0;
-		overflow: hidden;
-	}
+	#menuOverlay{ position:fixed; inset:0; background:rgba(0,0,0,.0); pointer-events:none; z-index:9999; }
+	#menuPanel{ position:absolute; top:-90%; left:50%; transform:translateX(-50%); width:min(760px,92vw); max-height:min(70vh,600px); background:#fff; color:#000; border-radius:0 0 10px 10px; box-shadow:0 20px 50px rgba(0,0,0,.35); display:grid; grid-template-rows:auto auto 1fr auto; overflow:hidden; transition:top .3s ease-in-out; }
+	#menuOverlay.active{ pointer-events:auto; } #menuOverlay.active #menuPanel{ top:0; }
+	#menuList{ list-style:none; margin:0; padding:6px 8px 12px 8px; overflow:auto; }
+	#menuHeader{ padding:12px 14px; font-weight:600; background:#111; color:#eee; }
+	#menuFilter{ margin:10px; padding:10px; font:inherit; border:1px solid #ccc; border-radius:8px; }
+	#menuList li{ padding:8px 10px; border-radius:8px; opacity:1; transform:translateY(0); transition:opacity .2s ease, transform .2s ease; }
+	#menuList li.fade-out{ opacity:0; transform:translateY(-10px); } #menuList li.fade-in{ opacity:0; transform:translateY(10px); animation:fadeInMove .2s forwards; }
+	@keyframes fadeInMove{ to{ opacity:1; transform:translateY(0);} }
+	#menuList li[data-active="true"]{ background:#111; color:#fff; }
+	#menuHint{ padding:8px 12px; font-size:.9em; color:#444; border-top:1px solid #eee; background:#fafafa; }
+	#menuTab{ position:fixed; top:0; left:50%; transform:translateX(-50%); background:#111; color:#eee; padding:4px 10px; font-size:.85em; border-radius:0 0 6px 6px; cursor:pointer; z-index:9998; }
+	#menuOverlay.active ~ #menuTab { display:none; }
 
-	/*  grid already splits header / main / composer; keep it */
-	body {
-		display: grid;
-		grid-template-rows: auto 1fr auto;
-	}
-
-	/* Allow the console (child) to actually shrink and become scrollable */
-	#main {
-		display: flex;
-		flex-direction: column;
-		min-height: 0;   /* critical with flex/grid parents */
-	}
-
-	/* Only the console scrolls */
-	#console {
-		display: flex;              /* <-- make children flex items */
-		flex-direction: column;     /* bubbles stack top→bottom */
-		align-items: flex-start;    /* default: left for non-user bubbles */
-		gap: 10px;                  /* spacing between bubbles */
-		flex: 1;
-		min-height: 0;
-		overflow: auto;
-		padding: 12px;
-	}
-
-	/* Make the composer look like a modern message bar: no top border, capsule input */
-	#composer {
-		display: flex;
-		gap: 8px;
-		padding: 8px 12px;
-		border-top: none;            /* remove the horizontal rule */
-		background: transparent;     /* no divider look */
-	}
-
-	#t {
-		flex: 1;
-		font: inherit;
-		padding: 10px 14px;
-		border: 1px solid #d9d9d9;   /* subtle, light grey */
-		border-radius: 9999px;         /* pill */
-		outline: none;
-		background: #fff;
-		/* very light inner depth like a modern message bar */
-		box-shadow: inset 0 1px 2px rgba(0,0,0,.06);
-	}
-	#t:focus {
-		border-color: #b9cdfd;
-		box-shadow:
-			0 0 0 2px rgba(80, 140, 255, .15),
-			inset 0 1px 2px rgba(0,0,0,.06);
-	}
-
-	/* Make the Send button match the modern message bar/pill vibe */
-	#send {
-		padding: 8px 14px;
-		border: 1px solid #d9d9d9;
-		border-radius: 9999px;
-		background: #f6f6f6;
-		font: inherit;
-		cursor: pointer;
-	}
-	#send:hover { background: #f0f0f0; }
-	#send:active { background: #eaeaea; }
-
-	pre { margin:0 0 8px 0; white-space:pre-wrap; }
-	
-	/* Base bubble look for all messages */
-	#console > .bubble {
-		white-space: normal;
-		margin: 0;                 /* rows are controlled by gap */
-		padding: 10px 12px;
-		border-radius: 10px;       /* not too rounded */
-		line-height: 1.35;
-		word-break: break-word;    /* avoid overflow for long tokens */
-		background: #1b1b1b;       /* default bubble bg */
-		border: 1px solid #333;
-		color: var(--fg);
-		max-width: min(70ch, 70%); /* message width cap */
-		align-self: flex-start;    /* default: left side */
-		font-family: system-ui, sans-serif; /* override monospace bubble look */
-	}
-
-	/* trim vertical margins inside the bubble */
-	#console .bubble > :first-child { margin-top: 0; }
-	#console .bubble > :last-child  { margin-bottom: 0; }	
-
-	/* User bubble (right side, “blue-ish” tone) */
-	#console > .bubble.user {
-		align-self: flex-end; /* right side */
-		background: #1d80ea;
-		border-color: #1d80ea;
-		color: #fafafa;
-	}
-
-	/* Assistant bubble (left, neutral dark) */
-	#console > .bubble.assistant {
-		background: #ddd;
-		border-color: #ddd;
-		color: #000;
-	}
-
-	/* Tool message: full-width, centered, visually distinct */
-	#console > .bubble.tool {
-		align-self: stretch;   /* span full row */
-		width: 100%;
-		max-width: none;
-		text-align: center;
-		background: #111;
-		border-color: #666;
-		font-weight: 600;
-	}
-
-	/* Optional: system messages centered, lighter text */
-	#console > .bubble.system {
-		align-self: stretch;
-		max-width: 80%;
-		background: #1a1a1a;
-		border-style: dashed;
-		color: #aaa;
-	}
-
-	#menuOverlay {
-		position: fixed;
-		inset: 0;
-		background: rgba(0,0,0,.0); /* transparent so clicks can still close if desired */
-		pointer-events: none;         /* disabled when menu is closed */
-		z-index: 9999;
-	}
-
-	#menuPanel {
-		position: absolute;
-		top: -90%; /* mostly hidden above */
-		left: 50%;
-		transform: translateX(-50%);
-		width: min(760px, 92vw);
-		max-height: min(70vh, 600px);
-		background: #fff;
-		color: #000;
-		border-radius: 0 0 10px 10px;
-		box-shadow: 0 20px 50px rgba(0,0,0,.35);
-		display: grid;
-		grid-template-rows: auto auto 1fr auto;
-		overflow: hidden;
-		transition: top 0.3s ease-in-out;
-	}
-
-	/* active state (pulled down) */
-	#menuOverlay.active { pointer-events: auto; }
-	#menuOverlay.active #menuPanel { top: 0; /* slide down into view */ }
-
-	/* menu item add/remove animation styles */
-	#menuList li {
-		padding: 8px 10px;
-		border-radius: 8px;
-		opacity: 1;
-		transform: translateY(0);
-		transition: opacity 0.2s ease, transform 0.2s ease;
-	}
-
-	#menuList li.fade-out {
-		opacity: 0;
-		transform: translateY(-10px);
-	}
-
-	#menuList li.fade-in {
-		opacity: 0;
-		transform: translateY(10px);
-		animation: fadeInMove 0.2s forwards;
-	}
-
-	@keyframes fadeInMove {
-		to { opacity: 1; transform: translateY(0); }
-	}
-
-	#menuHeader { padding:12px 14px; font-weight:600; background:#111; color:#eee; }
-	#menuFilter { margin:10px; padding:10px; font:inherit; border:1px solid #ccc; border-radius:8px; }
-	#menuList { list-style:none; margin:0; padding:6px 8px 12px 8px; overflow:auto; }
-	#menuList li { padding:8px 10px; border-radius:8px; }
-	#menuList li[data-active="true"] { background:#111; color:#fff; }
-	#menuHint { padding:8px 12px; font-size:.9em; color:#444; border-top:1px solid #eee; background:#fafafa; }
-
-	#menuTab {
-		position: fixed;
-		top: 0;
-		left: 50%;
-		transform: translateX(-50%);
-		background: #111;
-		color: #eee;
-		padding: 4px 10px;
-		font-size: 0.85em;
-		border-radius: 0 0 6px 6px;
-		cursor: pointer;
-		z-index: 9998;
-	}
-
-	#menuOverlay.active ~ #menuTab {
-		display: none;
-	}
-
-	#formOverlay {
-		position:fixed;
-		inset:0;
-		display:none;
-		align-items:center;
-		justify-content:center;
-		background:rgba(0,0,0,.55);
-		z-index:10000;
-	}
-
-	#formPanel {
-		background:#fff;
-		color:#000;
-		width:min(840px,92vw);
-		max-height:min(80vh,720px);
-		display:grid;
-		grid-template-rows:auto 1fr auto;
-		border-radius:12px;
-		overflow:hidden;
-		box-shadow:0 30px 70px rgba(0,0,0,.45);
-	}
-
-	#formTitle {
-		padding:14px 16px;
-		background:#111;
-		color:#eee;
-		font-weight:700;
-	}
-
-	#formBody {
-		overflow:auto;
-		padding:12px 16px;
-	}
-
-	#formFooter {
-		padding:10px 16px;
-		display:flex;
-		gap:8px;
-		justify-content:flex-end;
-		border-top:1px solid #eee;
-		background:#fafafa;
-	}
-
+	#formOverlay{ position:fixed; inset:0; display:none; align-items:center; justify-content:center; background:rgba(0,0,0,.55); z-index:10000; }
+	#formPanel{ background:#fff; color:#000; width:min(840px,92vw); max-height:min(80vh,720px); display:grid; grid-template-rows:auto 1fr auto; border-radius:12px; overflow:hidden; box-shadow:0 30px 70px rgba(0,0,0,.45);}
+	#formTitle{ padding:14px 16px; background:#111; color:#eee; font-weight:700; }
+	#formBody{ overflow:auto; padding:12px 16px; }
+	#formFooter{ padding:10px 16px; display:flex; gap:8px; justify-content:flex-end; border-top:1px solid #eee; background:#fafafa; }
+	.field-error{ color:#b00020; font-size:.9em; margin-top:4px; grid-column:2; }
+	input.invalid, select.invalid, textarea.invalid { border-color:#b00020 !important; outline:none; box-shadow:0 0 0 2px rgba(176,0,32,.15); }
+	.array-toolbar { display:flex; gap:6px; }
+	.array-list { list-style:none; margin:6px 0 0 0; padding:0; border:1px solid #eee; max-height:200px; overflow:auto; }
+	.array-list li { display:flex; justify-content:space-between; gap:8px; padding:6px 8px; border-bottom:1px solid #f1f1f1; }
+	.array-actions button { margin-left:6px; }
 </style>
+</head>
 <body>
 	<header></header>
 	<div id="menuTab">press ESC key to open</div>
 	<div id='main'>
-	<div id='console'></div> <!-- big scrollable console/log -->
+		<div id='console'> <!-- big scrollable console/log -->
 	</div>
 	<div id='composer'>
-	<input id='t' placeholder='Type and press Enter'/>
-	<button id='send'>Send</button>
+		<input id='t' placeholder='Type and press Enter'/>
+		<button id='send'>Send</button>
 	</div>
 	<!-- MENU OVERLAY -->
 	<div id="menuOverlay" hidden>
@@ -285,7 +78,7 @@
 				<button id="formSubmit" disabled>Submit</button>
 			</div>
 		</div>
-	</div>	
+	</div>
 <script src="marked.min.js"></script>
 <script>
 	const consoleEl = document.getElementById('console');
@@ -294,7 +87,7 @@
 
 	function post(obj) { try { window.external?.sendMessage?.(JSON.stringify(obj)); } catch {} }
 	function cwrite(s){ consoleEl.textContent += (s ?? ''); consoleEl.scrollTop = consoleEl.scrollHeight; }
-	function cwriteline(s){ cwrite((s ?? '') + '\n'); }
+	function cwriteline(s){ cwrite((s ?? '') + '\\n'); }
 
 	// --- menu controller ---------------------------------------------------------
 	const menuOverlay = document.getElementById('menuOverlay');
@@ -311,8 +104,8 @@
 	function openMenu(payload) {
 		menuState = {
 			header: payload.header || 'Menu',
-			choices: (payload.choices || []).slice(),
-			filtered: (payload.choices || []).slice(),
+			choices:[...(payload.choices || [])],
+			filtered:[...(payload.choices || [])],
 			idx: Math.min(Math.max(0, payload.selected|0), (payload.choices||[]).length-1)
 		};
 
@@ -322,7 +115,6 @@
 		menuOverlay.hidden = false;
 		menuOverlay.classList.add('active');
 		// Trap focus & keystrokes while menu is open
-		menuOverlay.hidden = false;
 		document.body.style.overflow = 'hidden';
 		t.disabled = true;
 		menuFilter.focus();
@@ -331,17 +123,11 @@
 	function closeMenu(sendResult) {
 		menuOverlay.classList.remove('active');
 		menuOverlay.hidden = true;
-
-		if (sendResult !== undefined) {
-			// Post selection/cancel to host so RenderMenu(...) can return synchronously.
-			post({ type:'MenuResult', text: sendResult ?? null });
-		}
-
+		if (sendResult !== undefined) post({ type:'MenuResult', text: sendResult ?? null });
 		document.body.style.overflow = '';
 		t.disabled = false;
 		t.focus();
 	}
-
 	function renderMenu() {
 		const q = menuFilter.value.trim().toLowerCase();
 		const newItems = q
@@ -382,24 +168,15 @@
 		const lis = [...menuList.querySelectorAll('li')];
 		lis.sort((a,b) => newItems.indexOf(a.dataset.value) - newItems.indexOf(b.dataset.value))
 			.forEach((li, i) => {
-				// normalize label
 				li.textContent = li.dataset.value;
-				// active row
-				li.dataset.active = (i === menuState.idx ? 'true' : 'false');
-				// click maps to current index
-				li.onclick = () => { menuState.idx = i; chooseActive(); };
-			});
-
-		// keep active visible
+				li.dataset.active = (i === menuState.idx ? 'true' : 'false'); li.onclick=()=>{ menuState.idx=i; chooseActive(); }; });
 		const active = menuList.querySelector('li[data-active="true"]');
-		if (active) {
-			const r = active.getBoundingClientRect();
-			const pr = menuList.getBoundingClientRect();
-			if (r.top < pr.top) menuList.scrollTop += r.top - pr.top;
-			else if (r.bottom > pr.bottom) menuList.scrollTop += r.bottom - pr.bottom;
+		if (active){
+			const r=active.getBoundingClientRect(), pr=menuList.getBoundingClientRect();
+			if (r.top<pr.top) menuList.scrollTop += r.top-pr.top;
+			else if (r.bottom>pr.bottom) menuList.scrollTop += r.bottom-pr.bottom;
 		}
 	}
-
 	function chooseActive() {
 		const items = menuState.filtered;
 		const chosen = (items.length > 0) ? items[menuState.idx] : null;
@@ -416,15 +193,15 @@
 			e.stopPropagation(); e.preventDefault();
 		}
 		const len = menuState.filtered.length;
-		switch (e.key) {
-			case 'ArrowUp':   if (len) menuState.idx = Math.max(0, menuState.idx-1); renderMenu(); break;
-			case 'ArrowDown': if (len) menuState.idx = Math.min(len-1, menuState.idx+1); renderMenu(); break;
-			case 'PageUp':    if (len) menuState.idx = Math.max(0, menuState.idx-10);  renderMenu(); break;
-			case 'PageDown':  if (len) menuState.idx = Math.min(len-1, menuState.idx+10); renderMenu(); break;
-			case 'Home':      if (len) menuState.idx = 0;            renderMenu(); break;
-			case 'End':       if (len) menuState.idx = len-1;        renderMenu(); break;
-			case 'Enter':     chooseActive(); break;
-			case 'Escape':    closeMenu(null); break; // close this menu, let host know it was cancelled
+		switch (e.key){
+			case 'ArrowUp':	 	if (len) menuState.idx = Math.max(0,menuState.idx-1); renderMenu(); break;
+			case 'ArrowDown': 	if (len) menuState.idx = Math.min(len-1,menuState.idx+1); renderMenu(); break;
+			case 'PageUp':	 	if (len) menuState.idx = Math.max(0,menuState.idx-10); renderMenu(); break;
+			case 'PageDown': 	if (len) menuState.idx = Math.min(len-1,menuState.idx+10); renderMenu(); break;
+			case 'Home':	 	if (len) menuState.idx = 0; renderMenu(); break;
+			case 'End':	 		if (len) menuState.idx = len-1; renderMenu(); break;
+			case 'Enter':	 	chooseActive(); break;
+			case 'Escape':	 	closeMenu(null); break; // close this menu, let host know it was cancelled
 		}
 	});
 
@@ -439,13 +216,18 @@
 	const formBody    = document.getElementById('formBody');
 	const formCancel  = document.getElementById('formCancel');
 	const formSubmit  = document.getElementById('formSubmit');
-	let formState = null;
+
+	let formState = null;              // { fields:[...] }
+	const idByKey = new Map();         // key -> element id
+	const errByKey = new Map();        // key -> error <div>
 
 	function openForm(payload) {
 		formTitle.textContent = payload.title || 'Input';
 		formBody.innerHTML = '';
 		formOverlay.style.display = 'flex';
 		document.body.style.overflow = 'hidden';
+
+		idByKey.clear(); errByKey.clear();
 
 		const fields = (payload.fields || []).map(f => ({ ...f, id: 'f_' + Math.random().toString(36).slice(2) }));
 		formState = { fields };
@@ -459,68 +241,271 @@
 			row.style.marginBottom = '12px';
 			row.style.alignItems = 'center';
 
+			// label
 			const lab = document.createElement('label');
 			lab.textContent = f.label + (f.required ? ' *' : '');
 			lab.setAttribute('for', f.id);
 			row.appendChild(lab);
 
-			let input;
-			if (f.kind === 'Number') {
+			// --- inputs by kind ---
+			let input; const kind = String(f.kind||'').toLowerCase();
+
+			const addHelp = (node) => {
+				const help = document.createElement('div');
+				help.textContent = f.help || '';
+				help.style.gridColumn = '1 / span 2';
+				help.style.color = '#555'; help.style.fontSize = '.92em'; help.style.padding = '4px 2px 0 2px';
+				row.appendChild(help);
+				return help;
+			};
+			const addError = () => {
+				const err = document.createElement('div');
+				err.className = 'field-error';
+				err.style.display = 'none';
+				row.appendChild(err);
+				errByKey.set(f.key, err);
+			};
+
+			if (kind === 'text'){
+				input = document.createElement('textarea');
+				input.rows = 4;
+				input.value = f.current ?? '';
+			} else if (kind === 'number') {
 				input = document.createElement('input');
 				input.type = 'number';
 				if (f.min != null) input.min = String(f.min);
 				if (f.max != null) input.max = String(f.max);
 				input.value = f.current ?? '';
-			} else if (f.kind === 'Bool') {
+			} else if (kind === 'decimal') {
+				input = document.createElement('input');
+				input.type = 'number';
+				input.step = 'any';
+				input.value = f.current ?? '';
+			} else if (kind === 'long') {
+				input = document.createElement('input');
+				input.type = 'number';
+				input.step = '1';
+				input.value = f.current ?? '';
+			} else if (kind === 'bool') {
 				input = document.createElement('select');
-				['false','true'].forEach(v => { const o = document.createElement('option'); o.value=v; o.textContent=v; input.appendChild(o); });
+				['false','true'].forEach(v => { const o=document.createElement('option'); o.value=v; o.textContent=v; input.appendChild(o); });
 				input.value = String(f.current ?? 'false');
-			} else if (f.kind === 'Enum') {
+			} else if (kind === 'enum') {
 				input = document.createElement('select');
-				(f.choices || []).forEach(v => { const o = document.createElement('option'); o.value=v; o.textContent=v; input.appendChild(o); });
+				(f.choices || []).forEach(v => { const o=document.createElement('option'); o.value=v; o.textContent=v; input.appendChild(o); });
 				if (f.current != null) input.value = String(f.current);
-			} else {
+			} else if (kind === 'date') {
+				input = document.createElement('input');
+				input.type = 'date';
+				input.value = f.current ?? '';
+			} else if (kind === 'time') {
+				input = document.createElement('input');
+				input.type = 'time';
+				input.value = f.current ?? '';
+			} else if (kind === 'guid') {
 				input = document.createElement('input');
 				input.type = 'text';
 				input.value = f.current ?? '';
-			}
-			input.id = f.id;
-			input.dataset.required = f.required ? '1' : '0';
-			row.appendChild(input);
+			} else if (kind === 'password') {
+				input = document.createElement('input');
+				input.type = 'password';
+				input.value = f.current ?? ''; 
+			} else if (kind === 'path') {
+				const wrap = document.createElement('div');
+				wrap.style.display = 'grid';
+				wrap.style.gridTemplateColumns = '1fr auto';
+				wrap.style.gap = '8px';
+				input=document.createElement('input');
+				input.type = 'text';
+				input.value = f.current ?? '';
+				const btn = document.createElement('button');
+				btn.type = 'button';
+				btn.textContent = 'Browse…';
+				btn.addEventListener('click', () => {
+					// Ask host; on next UserText, Photino wires it back to ReadPathWithAutocompleteAsync result
+					post({ type:'PromptPath', dir:false });
+					// Small hack: temporarily listen for a one-shot message by focusing and letting host put result back through FormError? Simpler: prompt()
+					// We keep a JS prompt fallback for now; Photino already handles PromptPath messages for host-driven pickers.
+					const p = prompt('Path:', input.value||'') || '';
+					if (p) input.value = p;
+					validateForm();
+				});
+				wrap.appendChild(input);
+				wrap.appendChild(btn);
+				row.appendChild(wrap);
+				addHelp(wrap);
+				addError();
+				gotoFinalize();
+				continue;
+			} else if (kind === 'array')
+			{ 
+				// simple repeater; current is JSON text
+				const container = document.createElement('div');
+				container.style.gridColumn = '2';
 
-			const help = document.createElement('div');
-			help.textContent = f.help || '';
-			help.style.gridColumn = '1 / span 2';
-			help.style.color = '#555';
-			help.style.fontSize = '.92em';
-			help.style.padding = '4px 2px 0 2px';
-			row.appendChild(help);
+				const toolbar = document.createElement('div');
+				toolbar.className='array-toolbar';
 
-			formBody.appendChild(row);
+				const addBtn = document.createElement('button');
+				addBtn.type='button'; addBtn.textContent='Add';
 
-			input.addEventListener('keydown', e => {
-				if (e.key === 'Enter' && input.tagName === 'INPUT') {
-					e.preventDefault();
-					const next = formBody.querySelectorAll('input,select');
-					const idx = Array.prototype.indexOf.call(next, input);
-					(next[idx + 1] || formSubmit).focus();
+				const editBtn = document.createElement('button');
+				editBtn.type='button'; editBtn.textContent='Edit';
+
+				const remBtn = document.createElement('button');
+				remBtn.type='button'; remBtn.textContent='Remove';
+
+				const list = document.createElement('ul');
+				list.className='array-list';
+
+				let items = [];
+				try {
+					items = JSON.parse(f.current||'[]') || [];
+				} catch { 
+					items = []; 
 				}
-			});
-			input.addEventListener('input', validateForm);
-			input.addEventListener('change', validateForm);
+
+				function renderList(){
+					list.innerHTML = '';
+					items.forEach((v,i)=>{
+						const li=document.createElement('li');
+						const span=document.createElement('span'); 
+						span.textContent = String(v);
+
+						const actions=document.createElement('div'); 
+						actions.className='array-actions';
+
+						const e=document.createElement('button'); 
+						e.type='button'; 
+						e.textContent='✎'; 
+						e.title='Edit';
+
+						const r=document.createElement('button'); 
+						r.type='button'; 
+						r.textContent='✕';
+						r.title='Remove';
+
+						e.onclick=()=>editItem(i); 
+						r.onclick=()=>{ 
+							items.splice(i,1); 
+							renderList(); 
+							validateForm();
+						};
+
+						actions.appendChild(e);
+						actions.appendChild(r);
+						li.appendChild(span);
+						li.appendChild(actions);
+						list.appendChild(li);
+					});
+				}
+
+				function editItem(i){
+					const curr = (i>=0)? String(items[i]) : '';
+					const val = prompt('Value:', curr);
+					if (val==null) return;
+					if (i>=0) items[i]=val; else items.push(val);
+					renderList();
+					validateForm();
+				}
+
+				addBtn.onclick=()=>editItem(-1);
+
+				editBtn.onclick=()=>{
+					const idx = Number(prompt('Index to edit (0-based):','0'));
+					if (!Number.isNaN(idx) && idx>=0 && idx<items.length) editItem(idx);
+				};
+
+				remBtn.onclick=()=>{ 
+					const idx = Number(prompt('Index to remove (0-based):','0'));
+					if (!Number.isNaN(idx) && idx>=0 && idx<items.length){
+						items.splice(idx,1);
+						renderList();
+						validateForm();
+					} 
+				};
+
+				renderList();
+
+				toolbar.appendChild(addBtn);
+				toolbar.appendChild(editBtn);
+				toolbar.appendChild(remBtn);
+
+				container.appendChild(toolbar);
+				container.appendChild(list);
+
+				// hidden backing input to carry JSON on submit
+				input = document.createElement('input');
+				input.type='hidden';
+				input.value = JSON.stringify(items);
+
+				container.appendChild(input);
+
+				row.appendChild(container);
+				addHelp(container); 
+				addError();
+				gotoFinalize(false /*no generic placement*/ , input, () => { input.value = JSON.stringify(items); });
+				continue;
+			} else { 
+				input=document.createElement('input');
+				input.type='text';
+				input.value=f.current ?? '';
+			}
+
+			// default placement (non-array)
+			row.appendChild(input);
+			addHelp(input);
+			addError();
+
+			function gotoFinalize(placeInput = true, backingInput = input, onBeforeSubmit = null) {
+				backingInput.id = f.id;
+				backingInput.dataset.key = f.key;
+				backingInput.dataset.required = f.required ? '1' : '0';
+				if (f.placeholder) backingInput.placeholder = f.placeholder;
+				if (f.pattern) backingInput.pattern = f.pattern;
+
+				idByKey.set(f.key, f.id);
+				if (placeInput){
+					backingInput.addEventListener('keydown', e=>{
+						if (e.key === 'Enter' && (backingInput.tagName==='INPUT' || backingInput.tagName==='SELECT')) {
+							e.preventDefault();
+							(formSubmit).focus();
+						}
+					});
+					backingInput.addEventListener('input', validateForm);
+					backingInput.addEventListener('change', validateForm);
+				}
+				// store per-field submit hook if provided
+				if (onBeforeSubmit){
+					if (!formState.beforeSubmit) formState.beforeSubmit = {};
+					formState.beforeSubmit[f.key] = onBeforeSubmit;
+				}
+				formBody.appendChild(row);
+			}
+			gotoFinalize();
 		}
 
 		validateForm();
-		(formBody.querySelector('input,select') || formSubmit).focus();
+		(formBody.querySelector('input,select,textarea') || formSubmit).focus();
 	}
 
 	function validateForm() {
-		const inputs = [...formBody.querySelectorAll('input,select')];
+		const inputs = [...formBody.querySelectorAll('input,select,textarea')].filter(el=>el.type!=='hidden');
 		let ok = true;
 		for (const el of inputs) {
+			el.classList.remove('invalid');
 			const required = el.dataset.required === '1';
 			const v = (el.tagName === 'SELECT') ? el.value : el.value.trim();
-			if (required && !v) { ok = false; break; }
+			if (required && !v) { ok = false; continue; }
+			if (el.pattern) {
+				try{
+					const re = new RegExp(el.pattern);
+					if (v && !re.test(v)) {
+						ok = false;
+						el.classList.add('invalid'); 
+					} 
+				} catch { /* bad pattern from host - ignore */ }
+			}
 		}
 		formSubmit.disabled = !ok;
 	}
@@ -529,30 +514,35 @@
 		if (!ok) {
 			post({ type: 'FormResult', ok: false });
 		} else {
+			// let fields with custom backing state (e.g., Array) push latest value
+			if (formState?.beforeSubmit) {
+				for (const [k,fn] of Object.entries(formState.beforeSubmit)) try{ fn(); }catch{}
+			}
 			const values = {};
 			for (const f of formState.fields) {
 				const el = document.getElementById(f.id);
-				values[f.label] = (el.tagName === 'SELECT') ? el.value : el.value;
+				values[f.key] = (el.tagName === 'SELECT') ? el.value : el.value;
 			}
 			post({ type: 'FormResult', ok: true, values });
 		}
 		formOverlay.style.display = 'none';
 		document.body.style.overflow = '';
 		formState = null;
+		idByKey.clear();
+		errByKey.clear();
 	}
 
 	formCancel.onclick = () => closeForm(false);
 	formSubmit.onclick = () => closeForm(true);
 	formOverlay.addEventListener('click', e => { if (e.target === formOverlay) closeForm(false); });
-	// --- end form controller ------------------------------------------------------
+	// --- end form controller ---------------------------------------------------------
 
-	// --- unified handler for ANY host→page message ---
+	// Unified handler
 	function handle(raw) {
 		try {
 			//cwriteline("RX: " + (typeof raw === 'string' ? raw : JSON.stringify(raw)));
 			const msg = (typeof raw === 'string') ? JSON.parse(raw) : raw;
 			if (!msg || !msg.type) return;
-
 			switch (msg.type) {
 				case 'AppendMessage': add((msg.role||'').toLowerCase(), msg.content||''); break;
 				case 'RenderHistory': consoleEl.innerHTML=''; (msg.items||[]).forEach(x=>add((x.role||'').toLowerCase(), x.content||'')); break;
@@ -561,17 +551,28 @@
 				case 'ShowMenu': openMenu(msg); break;
 				case 'ShowForm': openForm(msg); break;
 				case 'PromptLine': post({ type:'UserText', text: prompt('Input:', msg.placeholder||'') || '' }); break;
-				case 'PromptPath': post({ type:'UserText', text: prompt('Path:', '') || '' }); break;
+				case 'PromptPath': post({ type:'UserText', text: prompt('Path:', '') || '' }); break;  // host can also trigger this
 				case 'FocusInput': t.focus(); break;
 				case 'Clear': consoleEl.innerHTML=''; break;
+				case 'FormError': {
+					// payload: { type:'FormError', key, message }
+					if (!formState) break;
+					const { key, message } = msg;
+					const id = idByKey.get(key);
+					const err = errByKey.get(key);
+					if (id && err) {
+						const el = document.getElementById(id);
+						el?.classList.add('invalid');
+						err.textContent = message || 'Invalid value.';
+						err.style.display = '';
+						el?.focus();
+					}
+					break;
+				}
 			}
-		} catch (e) {
-			cwriteline(`RX error: ${e.message}`);
-		}
+		}catch(e){ cwriteline(`RX error: ${e.message}`); }
 	}
-
 	window.external.receiveMessage(message => handle(message));
-
 	function add(kind, text) {
 		const el = document.createElement('div');
 		el.className = 'bubble ' + (kind || '');

--- a/UX/wwwroot/index.html
+++ b/UX/wwwroot/index.html
@@ -339,22 +339,9 @@
 				continue;
 			} else if (kind === 'array')
 			{ 
-				// simple repeater; current is JSON text
+				// list
 				const container = document.createElement('div');
-				container.style.gridColumn = '2';
-
-				const toolbar = document.createElement('div');
-				toolbar.className='array-toolbar';
-
-				const addBtn = document.createElement('button');
-				addBtn.type='button'; addBtn.textContent='Add';
-
-				const editBtn = document.createElement('button');
-				editBtn.type='button'; editBtn.textContent='Edit';
-
-				const remBtn = document.createElement('button');
-				remBtn.type='button'; remBtn.textContent='Remove';
-
+				container.style.display = 'block';
 				const list = document.createElement('ul');
 				list.className='array-list';
 
@@ -409,30 +396,22 @@
 					validateForm();
 				}
 
-				addBtn.onclick=()=>editItem(-1);
-
-				editBtn.onclick=()=>{
-					const idx = Number(prompt('Index to edit (0-based):','0'));
-					if (!Number.isNaN(idx) && idx>=0 && idx<items.length) editItem(idx);
-				};
-
-				remBtn.onclick=()=>{ 
-					const idx = Number(prompt('Index to remove (0-based):','0'));
-					if (!Number.isNaN(idx) && idx>=0 && idx<items.length){
-						items.splice(idx,1);
-						renderList();
-						validateForm();
-					} 
-				};
+				// single add button at the bottom
+				const addRow = document.createElement('div');
+				addRow.style.display = 'flex';
+				addRow.style.justifyContent = 'flex-end';
+				addRow.style.marginTop = '6px';
+				const addBtn = document.createElement('button');
+				addBtn.type = 'button';
+				addBtn.textContent = '+';
+				addBtn.title = 'Add';
+				addBtn.onclick = () => editItem(-1);
+				addRow.appendChild(addBtn);
 
 				renderList();
 
-				toolbar.appendChild(addBtn);
-				toolbar.appendChild(editBtn);
-				toolbar.appendChild(remBtn);
-
-				container.appendChild(toolbar);
 				container.appendChild(list);
+				container.appendChild(addRow);
 
 				// hidden backing input to carry JSON on submit
 				input = document.createElement('input');
@@ -440,8 +419,8 @@
 				input.value = JSON.stringify(items);
 
 				container.appendChild(input);
-
 				row.appendChild(container);
+				
 				addHelp(container); 
 				addError();
 				gotoFinalize(false /*no generic placement*/ , input, () => { input.value = JSON.stringify(items); });

--- a/UserManagedData/DataCommands.cs
+++ b/UserManagedData/DataCommands.cs
@@ -61,8 +61,8 @@ public static class DataCommands
     {
         return new Command
         {
-            Name = "add",
-            Description = () => $"Add a new {metadata.Name} item",
+            Name = "CReate",
+            Description = () => $"Create a new {metadata.Name} item",
             Action = async () => await Log.MethodAsync(async ctx =>
             {
                 ctx.Append(Log.Data.Name, metadata.Name);
@@ -94,7 +94,7 @@ public static class DataCommands
     {
         return new Command
         {
-            Name = "update",
+            Name = "Update",
             Description = () => $"Update an existing {metadata.Name} item",
             Action = async () => await Log.MethodAsync(async ctx =>
             {
@@ -254,7 +254,7 @@ public static class DataCommands
     {
         return new Command
         {
-            Name = "delete",
+            Name = "Delete",
             Description = () => $"Delete a {metadata.Name} item",
             Action = () =>
             {

--- a/UserManagedData/DataCommands.cs
+++ b/UserManagedData/DataCommands.cs
@@ -146,60 +146,75 @@ public static class DataCommands
         {
             Name = "update",
             Description = () => $"Update an existing {metadata.Name} item",
-            Action = async () =>
+            Action = async () => await Log.MethodAsync(async ctx =>
             {
                 try
                 {
+                    ctx.Append(Log.Data.Name, metadata.Name);
+                    ctx.Append(Log.Data.Type, type.FullName ?? type.Name);
                     var (dataSubsystem, getMethod) = GetUserManagedGet(type);
-                    var itemsEnumerable = getMethod.Invoke(dataSubsystem, null) as IEnumerable;
-                    var items = itemsEnumerable?.Cast<object>().ToList() ?? new List<object>();
+                    var items = (getMethod.Invoke(dataSubsystem, null) as IEnumerable)?.Cast<object>().ToList() ?? new();
                     if (items.Count == 0)
                     {
-                        Program.ui.WriteLine($"No {metadata.Name} items found.");
+                        ctx.Append(Log.Data.Message, "No items found");
+                        ctx.Succeeded();
                         return Command.Result.Success;
                     }
 
-                    // Let user choose the item to edit
-                    var choices = items.Select((o, i) => $"{i}: {o}").ToList();
-                    var selected = Program.ui.RenderMenu($"Select {metadata.Name} to update:", choices);
+                    // pick
+                    var selected = Program.ui.RenderMenu($"Select {metadata.Name} to update:", items.Select((o,i)=>$"{i}: {o}").ToList());
                     if (selected == null)
                     {
-                        Program.ui.WriteLine("Update cancelled.");
+                        ctx.Append(Log.Data.Message, "User cancelled selection");
+                        ctx.Succeeded();
                         return Command.Result.Cancelled;
                     }
-                    var selectedIndex = int.Parse(selected.Split(':')[0]);
-                    var original = items[selectedIndex];
-
-                    // Clone original (json roundtrip) so we can edit without mutating predicate data
-                    // If ToJson/FromJson exist as extensions (they do elsewhere), use them when available.
-                    var editable = CloneViaJson(original, type) ?? Activator.CreateInstance(type)!;
-
-                    if (!await FillObjectInteractively(editable, type, isUpdate: true))
-                    {
-                        Program.ui.WriteLine("Update cancelled.");
-                        return Command.Result.Cancelled;
-                    }
-
-                    // Build a predicate: prefer [UserKey], else property named "Id"
+                    var idx = int.Parse(selected.Split(':')[0]);
+                    var original = items[idx];
+                    ctx.Append(Log.Data.Input, original.ToJson() ?? "<null>");
                     var keyProp = FindKeyProperty(type);
+                    ctx.Append(Log.Data.Key, keyProp?.Name ?? "<none>");
+
+                    // CAPTURE BEFORE EDITS
+                    object? keyValueBefore = keyProp != null ? keyProp.GetValue(original) : null;
+                    var originalJsonBefore = keyProp == null ? original.ToJson() : null;
+
+                    // build a form on a clone
+                    var editable = CloneViaJson(original, type) ?? Activator.CreateInstance(type)!;
+                    var form = UiFormBuilder.BuildForm(editable, type, $"Edit {metadata.Name}");
+
+                    // show the form
+                    if (!await Program.ui.ShowFormAsync(form))
+                    {
+                        ctx.Append(Log.Data.Message, "User cancelled form");
+                        ctx.Succeeded();
+                        return Command.Result.Cancelled;
+                    }
+
+                    // GET THE EDITED MODEL (don’t rely on ApplyEditsToOriginal)
+                    ctx.Append(Log.Data.Output, form.Model?.ToJson() ?? "<null>");
+                    var edited = (object?)form.Model ?? editable;
+
+                    // (optional) keep this if you want in-place copy too, but it’s not required
+                    // form.ApplyEditsToOriginal(original);
+
+                    // build predicate using BEFORE state (unchanged)
                     Delegate predicate;
                     if (keyProp != null)
                     {
-                        var keyValue = keyProp.GetValue(original);
-                        predicate = BuildEqualityPredicate(type, keyProp, keyValue);
+                        predicate = BuildEqualityPredicate(type, keyProp, keyValueBefore);
                     }
                     else
                     {
-                        // Fallback: match by JSON snapshot (less ideal but works generically)
-                        var originalJson = original.ToJson();
-                        predicate = BuildJsonEqualityPredicate(type, originalJson);
+                        predicate = BuildJsonEqualityPredicate(type, originalJsonBefore!);
                     }
 
+                    // persist the EDITED instance
                     var (subsystemForUpdate, updateMethod) = GetUserManagedUpdate(type);
-                    updateMethod.Invoke(subsystemForUpdate, new[] { editable, predicate });
+                    updateMethod.Invoke(subsystemForUpdate, new[] { edited, predicate });
 
                     Config.Save(Program.config, Program.ConfigFilePath);
-                    Program.ui.WriteLine($"Updated {metadata.Name}: {editable}");
+                    Program.ui.WriteLine($"Updated {metadata.Name}: {edited}");
                     return Command.Result.Success;
                 }
                 catch (Exception ex)
@@ -207,319 +222,11 @@ public static class DataCommands
                     Program.ui.WriteLine($"Error updating {metadata.Name}: {ex.Message}");
                     return Command.Result.Failed;
                 }
-            }
+            })
         };
     }
 
-    /* --------------------------- helpers --------------------------- */
-
-    private static async Task<bool> FillObjectInteractively(object obj, Type type, bool isUpdate)
-    {
-        foreach (var prop in GetEditableProperties(type))
-        {
-            var uf = prop.GetCustomAttribute<UserFieldAttribute>();
-            var required = uf?.Required ?? false;
-            var display = uf?.Display ?? prop.Name;
-            var hint = uf?.Hint;
-
-            var propType = prop.PropertyType;
-            var current = prop.GetValue(obj);
-
-            if (IsSimple(propType))
-            {
-                var ok = PromptForSimple(ref current, propType, display, required, isUpdate, hint);
-                if (!ok) return false;
-                prop.SetValue(obj, current);
-            }
-            else if (IsList(propType, out var elemType))
-            {
-                var listInstance = current as IList;
-                if (listInstance == null)
-                {
-                    listInstance = (IList)(Activator.CreateInstance(typeof(List<>).MakeGenericType(elemType))!);
-                }
-                if (!await EditListInteractively(listInstance, elemType, display, isUpdate))
-                    return false;
-                prop.SetValue(obj, listInstance);
-            }
-            else // complex object
-            {
-                Program.ui.WriteLine($"\n-- {display} {(required ? "(required)" : "(optional)")} --");
-                var child = current ?? Activator.CreateInstance(propType)!;
-
-                // allow skipping optional complex properties
-                if (!required)
-                {
-                    Program.ui.Write($"Edit {display}? (y/N): ");
-                    var ans = (Program.ui.ReadLine() ?? "").Trim();
-                    if (!ans.Equals("y", StringComparison.OrdinalIgnoreCase))
-                        continue;
-                }
-
-                if (!await FillObjectInteractively(child, propType, isUpdate))
-                    return false;
-
-                prop.SetValue(obj, child);
-            }
-        }
-        return true;
-    }
-
-    private static IEnumerable<PropertyInfo> GetEditableProperties(Type t) =>
-        t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-        .Where(p => p.CanRead && p.CanWrite && p.GetIndexParameters().Length == 0);
-
-    private static bool PromptForSimple(ref object? value, Type type, string display, bool required, bool isUpdate, string? hint)
-    {
-        while (true)
-        {
-            var currentText = isUpdate && value != null ? $" [{FormatValue(value)}]" : "";
-            var requiredText = required ? " (required)" : " (optional)";
-            if (!string.IsNullOrWhiteSpace(hint)) Program.ui.WriteLine(hint);
-            Program.ui.Write($"{display}{requiredText}:{currentText} ");
-
-            var input = ReadLineAllowEsc();
-            if (input == null)
-            {
-                // ESC pressed -> cancel the whole interactive fill
-                return false;
-            }
-            if (string.IsNullOrWhiteSpace(input))
-            {
-                if (isUpdate && value != null) return true;         // keep existing
-                if (!required) { value = GetDefault(type); return true; }
-                // else required and empty -> re-prompt
-                Program.ui.WriteLine("Value is required.");
-                continue;
-            }
-
-            if (TryParse(type, input!, out var parsed))
-            {
-                value = parsed;
-                return true;
-            }
-            Program.ui.WriteLine($"Could not parse '{input}' as {PrettyType(type)}. Try again.");
-        }
-    }
-
-    private static string? ReadLineAllowEsc()
-    {
-        // Read first key to detect ESC without consuming input from Program.ui.ReadLine
-        var key = Program.ui.ReadKey(intercept: true);
-        if (key.Key == ConsoleKey.Escape)
-        {
-            Program.ui.WriteLine();
-            return null;
-        }
-        if (key.Key == ConsoleKey.Enter)
-        {
-            Program.ui.WriteLine();
-            return string.Empty;
-        }
-
-        // Echo the first key and read the remainder of the line
-        Program.ui.Write(key.KeyChar.ToString());
-        var rest = Program.ui.ReadLine();
-        return key.KeyChar + (rest ?? "");
-    }
-
-    private static async Task<bool> EditListInteractively(IList list, Type elemType, string display, bool isUpdate)
-    {
-        while (true)
-        {
-            var choices = new List<string>
-            {
-                "list    (show items)",
-                "add     (insert new item)",
-                "edit    (modify an item)",
-                "remove  (delete an item)",
-                "done    (finish editing)"
-            };
-
-            var choice = Program.ui.RenderMenu($"Choose action: {display}", choices);
-            if (choice == null || choice.StartsWith("done", StringComparison.OrdinalIgnoreCase))
-                return true;
-
-            if (choice.StartsWith("list", StringComparison.OrdinalIgnoreCase))
-            {
-                if (list.Count == 0)
-                {
-                    Program.ui.WriteLine("List is empty.");
-                    continue;
-                }
-
-                var itemChoices = new List<string>();
-                for (int i = 0; i < list.Count; i++)
-                    itemChoices.Add(FormatValue(list[i]));
-
-                // Use RenderMenu so the items are visible while selecting; ESC (null) goes back
-                var seen = Program.ui.RenderMenu($"Items in {display} (press ESC to go back)", itemChoices);
-                // ignore selection results; null returns to main menu
-                continue;
-            }
-
-            if (choice.StartsWith("add", StringComparison.OrdinalIgnoreCase))
-            {
-                if (IsSimple(elemType))
-                {
-                    // Prompt manually so ESC or blank entry cancels the add (but does not abort the whole edit session)
-                    var hint = GetTypeInputHint(elemType);
-                    Program.ui.Write($"Enter value ({hint}) or press ESC to cancel: ");
-                    var input = ReadLineAllowEsc();
-                    if (input == null || string.IsNullOrWhiteSpace(input))
-                    {
-                        Program.ui.WriteLine("Add cancelled.");
-                        continue; // do not add, keep editing
-                    }
-
-                    if (TryParse(elemType, input!, out var parsed))
-                    {
-                        list.Add(parsed!);
-                    }
-                    else
-                    {
-                        Program.ui.WriteLine($"Could not parse '{input}' as {PrettyType(elemType)}. Add cancelled.");
-                        continue;
-                    }
-                }
-                else
-                {
-                    var child = Activator.CreateInstance(elemType)!;
-                    if (!await FillObjectInteractively(child, elemType, isUpdate: false))
-                    {
-                        Program.ui.WriteLine("Add cancelled.");
-                        continue; // user cancelled adding the complex item
-                    }
-                    list.Add(child);
-                }
-            }
-            else if (choice.StartsWith("edit", StringComparison.OrdinalIgnoreCase))
-            {
-                if (list.Count == 0) { Program.ui.WriteLine("List is empty."); continue; }
-
-                var itemChoices = new List<string>();
-                for (int i = 0; i < list.Count; i++)
-                    itemChoices.Add(FormatValue(list[i]));
-
-                var selected = Program.ui.RenderMenu($"Select {display} item to edit (press ESC to cancel):", itemChoices);
-                if (selected == null)
-                {
-                    Program.ui.WriteLine("Edit cancelled.");
-                    continue;
-                }
-
-                var selectedIndex = itemChoices.IndexOf(selected);
-                if (selectedIndex < 0) { Program.ui.WriteLine("Invalid selection."); continue; }
-
-                if (IsSimple(elemType))
-                {
-                    object? cur = list[selectedIndex];
-                    var hint = GetTypeInputHint(elemType);
-                    Program.ui.Write($"Enter new value for index {selectedIndex} ({hint}) or press ESC to cancel: ");
-                    var input = ReadLineAllowEsc();
-                    if (input == null || string.IsNullOrWhiteSpace(input))
-                    {
-                        Program.ui.WriteLine("Edit cancelled.");
-                        continue;
-                    }
-                    if (TryParse(elemType, input!, out var parsed))
-                    {
-                        list[selectedIndex] = parsed!;
-                    }
-                    else
-                    {
-                        Program.ui.WriteLine($"Could not parse '{input}' as {PrettyType(elemType)}. Edit cancelled.");
-                        continue;
-                    }
-                }
-                else
-                {
-                    var child = list[selectedIndex] ?? Activator.CreateInstance(elemType)!;
-                    if (!await FillObjectInteractively(child!, elemType, isUpdate: true))
-                    {
-                        Program.ui.WriteLine("Edit cancelled.");
-                        continue;
-                    }
-                    list[selectedIndex] = child!;
-                }
-            }
-            else if (choice.StartsWith("remove", StringComparison.OrdinalIgnoreCase))
-            {
-                if (list.Count == 0) { Program.ui.WriteLine("List is empty."); continue; }
-
-                var itemChoices = new List<string>();
-                for (int i = 0; i < list.Count; i++)
-                    itemChoices.Add(FormatValue(list[i]));
-
-                var selected = Program.ui.RenderMenu($"Select {display} item to remove (press ESC to cancel):", itemChoices);
-                if (selected == null)
-                {
-                    Program.ui.WriteLine("Remove cancelled.");
-                    continue;
-                }
-
-                var removeIndex = itemChoices.IndexOf(selected);
-                if (removeIndex < 0) { Program.ui.WriteLine("Invalid selection."); continue; }
-
-                Program.ui.Write($"Are you sure you want to remove '{list[removeIndex]}'? (y/N): ");
-                var confirm = ReadLineAllowEsc();
-                if (confirm == null || !string.Equals(confirm, "y", StringComparison.OrdinalIgnoreCase))
-                {
-                    Program.ui.WriteLine("Remove cancelled.");
-                    continue;
-                }
-
-                list.RemoveAt(removeIndex);
-            }
-        }
-    }
-
     /* ---------- parsing & utilities ---------- */
-
-    private static bool IsSimple(Type t)
-    {
-        t = Nullable.GetUnderlyingType(t) ?? t;
-        return t.IsPrimitive || t.IsEnum ||
-            t == typeof(string) || t == typeof(decimal) ||
-            t == typeof(DateTime) || t == typeof(Guid) ||
-            t == typeof(double) || t == typeof(float) ||
-            t == typeof(int) || t == typeof(long) ||
-            t == typeof(short) || t == typeof(byte) ||
-            t == typeof(bool);
-    }
-
-    private static bool IsList(Type t, out Type elemType)
-    {
-        if (t.IsArray)
-        {
-            elemType = t.GetElementType()!;
-            return true;
-        }
-        if (t.IsGenericType && typeof(IList).IsAssignableFrom(t))
-        {
-            elemType = t.GetGenericArguments()[0];
-            return true;
-        }
-        if (t.IsGenericType && t.GetInterfaces().Any(i => i == typeof(IList))) // safety
-        {
-            elemType = t.GetGenericArguments()[0];
-            return true;
-        }
-        // handle List<T> properties typed as IList<T>/ICollection<T>/IEnumerable<T>
-        var listIface = t.GetInterfaces().FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IList<>));
-        if (listIface != null)
-        {
-            elemType = listIface.GetGenericArguments()[0];
-            return true;
-        }
-        elemType = typeof(object);
-        return false;
-    }
-
-    private static object? GetDefault(Type type) =>
-        type.IsValueType ? Activator.CreateInstance(type) : null;
-
-    private static string PrettyType(Type t) => (Nullable.GetUnderlyingType(t) ?? t).Name;
 
     private static string FormatValue(object? v) =>
         v == null ? "null" :
@@ -528,43 +235,6 @@ public static class DataCommands
             ? "[" + string.Join(", ", e.Cast<object>().Select(FormatValue)) + "]"
             : v.ToString() ?? "";
 
-    private static bool TryParse(Type type, string input, out object? value)
-    {
-        var t = Nullable.GetUnderlyingType(type) ?? type;
-
-        if (t == typeof(string)) { value = input; return true; }
-        if (t == typeof(int)) { if (int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i)) { value = i; return true; } }
-        if (t == typeof(long)) { if (long.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var l)) { value = l; return true; } }
-        if (t == typeof(short)) { if (short.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var s)) { value = s; return true; } }
-        if (t == typeof(byte)) { if (byte.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var b)) { value = b; return true; } }
-        if (t == typeof(decimal)) { if (decimal.TryParse(input, NumberStyles.Number, CultureInfo.InvariantCulture, out var d)) { value = d; return true; } }
-        if (t == typeof(double)) { if (double.TryParse(input, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var f)) { value = f; return true; } }
-        if (t == typeof(float)) { if (float.TryParse(input, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var fl)) { value = fl; return true; } }
-        if (t == typeof(bool)) { if (bool.TryParse(input, out var bo)) { value = bo; return true; } }
-        if (t == typeof(Guid)) { if (Guid.TryParse(input, out var g)) { value = g; return true; } }
-        if (t == typeof(DateTime)) { if (DateTime.TryParse(input, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var dt)) { value = dt; return true; } }
-        if (t.IsEnum)
-        {
-            // allow numeric or named values (case-insensitive)
-            if (Enum.TryParse(t, input, ignoreCase: true, out var ev)) { value = ev; return true; }
-        }
-
-        value = null;
-        return false;
-    }
-
-    private static string GetTypeInputHint(Type type)
-    {
-        var t = Nullable.GetUnderlyingType(type) ?? type;
-        if (t == typeof(string)) return "text";
-        if (t == typeof(int) || t == typeof(long) || t == typeof(short) || t == typeof(byte)) return "integer";
-        if (t == typeof(decimal) || t == typeof(double) || t == typeof(float)) return "number";
-        if (t == typeof(bool)) return "true/false";
-        if (t == typeof(Guid)) return "guid (e.g. 01234567-89ab-cdef-0123-456789abcdef)";
-        if (t == typeof(DateTime)) return "datetime (ISO, e.g. 2023-05-01T12:00:00Z)";
-        if (t.IsEnum) return "one of: " + string.Join("|", Enum.GetNames(t));
-        return PrettyType(t);
-    }
 
     /* ---------- subsystem access via reflection (supports both classes present) ---------- */
 

--- a/command-reference.md
+++ b/command-reference.md
@@ -83,13 +83,11 @@ RAG enhances language model responses by retrieving information from a knowledge
 - **`rag clear`**: Clear all data from the RAG store.
 - **`rag search`**: Query the RAG store with a search string to retrieve relevant matched chunks.
 
-**Configuring RAG:**
-- **`rag config embedding model`**: Set the embedding model (used to generate vector representations of text).
-- **`rag config query`**: Customize the query prompt for searching the RAG store.
-- **`rag config chunking method`**: Select a text chunking method for breaking documents into smaller pieces.
-- **`rag config chunksize`**: Set the number of tokens in each chunk (to control the size of document fragments).
-- **`rag config overlap`**: Define the overlap between chunks (to ensure smooth transitions in content).
-- **`rag config TopK`**: Specify the number of top results to return from searches.
+**Configuring RAG (Grouped Forms):**
+- **`rag config core settings`**: Edit embeddings on/off, embedding model, TopK, TopKForParsing, embedding + ingest concurrency.
+- **`rag config chunking`**: Edit chunking strategy, chunk size, max tokens per chunk, max line length, overlap.
+- **`rag config mmr`**: Edit MMR use, lambda, pool multiplier, minimum extra candidates.
+- **`rag config file types`**: Manage supported file extensions (add/edit/delete) with include/exclude regex lists (UserManagedData backed).
 
 ### Usage Example:
 1. **Add data to the store:**
@@ -129,11 +127,9 @@ RAG enhances language model responses by retrieving information from a knowledge
 |                          | `rag status`                      | Show the RAG store's status.                 |
 |                          | `rag clear`                       | Clear the RAG store.                         |
 |                          | `rag search`                      | Search the RAG store with a query.           |
-|                          | `rag config embedding model`      | Set the embedding model.                     |
-|                          | `rag config query`                | Customize the query prompt.                  |
-|                          | `rag config chunking method`      | Choose a chunking strategy.                  |
-|                          | `rag config chunksize`            | Set the chunk size in tokens.                |
-|                          | `rag config overlap`              | Set overlap between chunks.                  |
-|                          | `rag config TopK`                 | Specify the number of top results to return. |
+|                          | `rag config core settings`        | Edit core embedding + retrieval settings.    |
+|                          | `rag config chunking`             | Edit chunking strategy and sizes.            |
+|                          | `rag config mmr`                  | Edit MMR settings.                           |
+|                          | `rag config file types`           | Manage supported file types (UMD).           |
 
 ---


### PR DESCRIPTION
This pull request refactors several command handlers across the codebase to use structured UI forms for user input, improving consistency and user experience. It replaces ad-hoc `ReadLine` prompts with strongly-typed models and form-based input, streamlining configuration changes and command interactions. Additionally, there are minor improvements to field metadata and command descriptions.

**UI Form Refactoring and Input Handling:**

* Most commands in `Commands/ProviderCommands.cs`, `Commands/RagCommands.cs`, and `Commands.cs` now use `UiForm` for user input, replacing manual `ReadLine` prompts. This includes configuration changes (provider, model, host, system prompt, temperature, max tokens, Azure logging), RAG commands (graph walk, community info, export summary), and tool input. Strongly-typed models are introduced for these forms.

* The "new chat name" command in `ChatCommands.cs` now uses a form for input, improving clarity and consistency with other commands.

**Field Metadata Improvements:**

* The `Description` field in `ChatThread.cs` is now explicitly marked as a text field in the UI, which may improve form rendering and validation.

**Command Description and Output Adjustments:**

* Command descriptions and prompts have been updated for clarity and to reflect current values in a more user-friendly format. 

**Minor Codebase Cleanups:**
Removed unnecessary output and error handling in some commands, relying on form validation and result status instead. 

**Unified Form-based Configuration UI:**

* Refactored provider configuration commands in `Commands/ProviderCommands.cs` (such as changing host, system prompt, temperature, max tokens, and Azure auth logging) to use `UiForm` with async actions, providing a more consistent and user-friendly experience.
* Updated RAG configuration commands in `Commands/RagConfigCommands.cs` (use embeddings, embedding model, embedding concurrency, ingest concurrency) to use `UiForm` for input, replacing previous manual input and menu selection.
* Changed the "default new chat name" command in `Chat/ChatCommands.cs` to use `UiForm` for setting the default chat thread name, improving UX and validation.

**Command Behavior and UX Improvements:**

* Modified event source toggling in `Commands/ProviderCommands.cs` to improve menu labeling and return `Cancelled` when no valid selection is made, instead of always returning `Success`.
* Updated several command descriptions and names for clarity (e.g., "Change Ollama host" to "Change host", and improved help texts and prompts).
